### PR TITLE
[feat] 모달VC 구현 완료

### DIFF
--- a/TripLog/TripLog/Feat-Crois/ModalViewController/Model/Currencys.swift
+++ b/TripLog/TripLog/Feat-Crois/ModalViewController/Model/Currencys.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 
+/// 모든 통화를 모아두는 enum
 enum Currency: String, CaseIterable {
     case KRW = "원(한화)"         // 대한민국
     case USD = "USD(달러)"       // 미국

--- a/TripLog/TripLog/Feat-Crois/ModalViewController/Model/Currencys.swift
+++ b/TripLog/TripLog/Feat-Crois/ModalViewController/Model/Currencys.swift
@@ -1,0 +1,43 @@
+//
+//  Currencys.swift
+//  TripLog
+//
+//  Created by 장상경 on 1/21/25.
+//
+
+import Foundation
+
+enum Currency: String, CaseIterable {
+    case KRW = "원(한화)"         // 대한민국
+    case USD = "USD(달러)"       // 미국
+    case EUR = "EUR(유로)"       // 유럽 연합
+    case JPY = "JPY(엔)"         // 일본
+    case CNY = "CNY(위안)"       // 중국
+    case GBP = "GBP(파운드)"     // 영국
+    case AUD = "AUD(호주 달러)"  // 호주
+    case CAD = "CAD(캐나다 달러)" // 캐나다
+    case CHF = "CHF(스위스 프랑)" // 스위스
+    case HKD = "HKD(홍콩 달러)"  // 홍콩
+    case NZD = "NZD(뉴질랜드 달러)" // 뉴질랜드
+    case SGD = "SGD(싱가포르 달러)" // 싱가포르
+    case SEK = "SEK(스웨덴 크로나)" // 스웨덴
+    case NOK = "NOK(노르웨이 크로네)" // 노르웨이
+    case DKK = "DKK(덴마크 크로네)" // 덴마크
+    case ZAR = "ZAR(남아프리카 랜드)" // 남아프리카공화국
+    case INR = "INR(루피)"       // 인도
+    case MYR = "MYR(링깃)"      // 말레이시아
+    case IDR = "IDR(루피아)"     // 인도네시아
+    case PHP = "PHP(페소)"      // 필리핀
+    case THB = "THB(바트)"       // 태국
+    case MXN = "MXN(멕시코 페소)" // 멕시코
+    case VND = "VND(동)"        // 베트남
+    case BRL = "BRL(브라질 헤알)" // 브라질
+    case RUB = "RUB(루블)"      // 러시아
+    case SAR = "SAR(리얄)"      // 사우디아라비아
+    case TRY = "TRY(리라)"      // 터키
+
+    // 모든 케이스의 배열 제공
+    static var allCurrencies: [String] {
+        return Self.allCases.reversed().map { $0.rawValue }
+    }
+}

--- a/TripLog/TripLog/Feat-Crois/ModalViewController/Model/ModalDatePickerDirection.swift
+++ b/TripLog/TripLog/Feat-Crois/ModalViewController/Model/ModalDatePickerDirection.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 
+/// 모달의 데이트픽커 방향을 설정하는 enum
 enum ModalDatePickerDirection {
     case right
     case left

--- a/TripLog/TripLog/Feat-Crois/ModalViewController/Model/ModalDatePickerDirection.swift
+++ b/TripLog/TripLog/Feat-Crois/ModalViewController/Model/ModalDatePickerDirection.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-/// 모달의 데이트픽커 방향을 설정하는 enum
+/// 모달의 DatePicker 방향을 설정하는 enum
 enum ModalDatePickerDirection {
     case right
     case left

--- a/TripLog/TripLog/Feat-Crois/ModalViewController/Model/ModalDatePickerDirection.swift
+++ b/TripLog/TripLog/Feat-Crois/ModalViewController/Model/ModalDatePickerDirection.swift
@@ -1,0 +1,13 @@
+//
+//  ModalDatePickerDirection.swift
+//  TripLog
+//
+//  Created by 장상경 on 1/21/25.
+//
+
+import Foundation
+
+enum ModalDatePickerDirection {
+    case right
+    case left
+}

--- a/TripLog/TripLog/Feat-Crois/ModalViewController/Model/ModalViewManager.swift
+++ b/TripLog/TripLog/Feat-Crois/ModalViewController/Model/ModalViewManager.swift
@@ -9,8 +9,24 @@ import UIKit
 import RxSwift
 import RxCocoa
 
+/// 모달 뷰와 관련된 전역 메소드를 관리하는 enum
 enum ModalViewManager {
     
+    /// 모달VC를 present 하는 메소드
+    /// - Parameters:
+    ///   - view: 모달VC를 present 할 뷰 컨트롤러
+    ///   - state: 모달VC의 상태(가계부 추가, 지출 내역 추가, 지출 내역 수정)
+    /// - Returns: 모달VC의 active 버튼이 클릭되었다는 이벤트를 방출하는 옵저버블
+    ///
+    /// - Example
+    /// ```swift
+    /// ModalViewManager.showModal(on: self, state: .editBudget(data: data))
+    ///     .subscribe(onNext: { _ in
+    ///         print("Completed")
+    ///     }).disposed(by: disposeBag)
+    /// ```
+    ///
+    /// ``ModalViewState``
     static func showModal(on view: UIViewController, state: ModalViewState) -> Observable<Void> {
         let modalVC = ModalViewController(state: state)
         view.present(modalVC, animated: true)

--- a/TripLog/TripLog/Feat-Crois/ModalViewController/Model/ModalViewManager.swift
+++ b/TripLog/TripLog/Feat-Crois/ModalViewController/Model/ModalViewManager.swift
@@ -1,0 +1,21 @@
+//
+//  ModalViewManager.swift
+//  TripLog
+//
+//  Created by 장상경 on 1/22/25.
+//
+
+import UIKit
+import RxSwift
+import RxCocoa
+
+enum ModalViewManager {
+    
+    static func showModal(on view: UIViewController, state: ModalViewState) -> Observable<Void> {
+        let modalVC = ModalViewController(state: state)
+        view.present(modalVC, animated: true)
+        
+        return modalVC.rx.completedLogic.asObservable()
+    }
+    
+}

--- a/TripLog/TripLog/Feat-Crois/ModalViewController/Model/ModalViewState.swift
+++ b/TripLog/TripLog/Feat-Crois/ModalViewController/Model/ModalViewState.swift
@@ -1,0 +1,25 @@
+//
+//  ModalViewState.swift
+//  TripLog
+//
+//  Created by 장상경 on 1/20/25.
+//
+
+import Foundation
+
+enum ModalViewState {
+    case createNewCashBook
+    case createNewbudget
+    case editBudget
+    
+    var modalTitle: String {
+        switch self {
+        case .createNewCashBook:
+            return "새 가계부 만들기"
+        case .createNewbudget:
+            return "새 지출내역 추가하기"
+        case .editBudget:
+            return "지출내역 수정하기"
+        }
+    }
+}

--- a/TripLog/TripLog/Feat-Crois/ModalViewController/Model/ModalViewState.swift
+++ b/TripLog/TripLog/Feat-Crois/ModalViewController/Model/ModalViewState.swift
@@ -7,11 +7,13 @@
 
 import Foundation
 
+/// 모달 뷰의 상태를 정의하는 enum
 enum ModalViewState {
     case createNewCashBook
     case createNewbudget
-    case editBudget(data: TestModalViewData)
+    case editBudget(data: TestModalViewData) // 지출 내역 수정 시 데이터 입력
     
+    /// 각 상태에 따라 모달 뷰의 타이틀을 결정하는 프로퍼티
     var modalTitle: String {
         switch self {
         case .createNewCashBook:

--- a/TripLog/TripLog/Feat-Crois/ModalViewController/Model/ModalViewState.swift
+++ b/TripLog/TripLog/Feat-Crois/ModalViewController/Model/ModalViewState.swift
@@ -10,7 +10,7 @@ import Foundation
 enum ModalViewState {
     case createNewCashBook
     case createNewbudget
-    case editBudget
+    case editBudget(data: TestModalViewData)
     
     var modalTitle: String {
         switch self {

--- a/TripLog/TripLog/Feat-Crois/ModalViewController/Model/TestModalViewData.swift
+++ b/TripLog/TripLog/Feat-Crois/ModalViewController/Model/TestModalViewData.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 
+/// 테스트용 더미 데이터
 struct TestModalViewData {
     let isCardPayment: Bool
     let expenseDetails: String?

--- a/TripLog/TripLog/Feat-Crois/ModalViewController/Model/TestModalViewData.swift
+++ b/TripLog/TripLog/Feat-Crois/ModalViewController/Model/TestModalViewData.swift
@@ -1,0 +1,16 @@
+//
+//  TestModalViewData.swift
+//  TripLog
+//
+//  Created by 장상경 on 1/22/25.
+//
+
+import Foundation
+
+struct TestModalViewData {
+    let isCardPayment: Bool
+    let expenseDetails: String?
+    let category: String?
+    let carrency: Currency
+    let amount: Int?
+}

--- a/TripLog/TripLog/Feat-Crois/ModalViewController/View/ModalAmoutView.swift
+++ b/TripLog/TripLog/Feat-Crois/ModalViewController/View/ModalAmoutView.swift
@@ -58,6 +58,13 @@ final class ModalAmoutView: UIView {
         fatalError("init(coder:) has not been implemented")
     }
     
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+        if traitCollection.hasDifferentColorAppearance(comparedTo: previousTraitCollection) {
+            self.textField.layer.borderColor = UIColor.Dark.base.withAlphaComponent(0.1).cgColor
+        }
+    }
+    
 }
 
 private extension ModalAmoutView {

--- a/TripLog/TripLog/Feat-Crois/ModalViewController/View/ModalAmoutView.swift
+++ b/TripLog/TripLog/Feat-Crois/ModalViewController/View/ModalAmoutView.swift
@@ -9,7 +9,10 @@ import UIKit
 import SnapKit
 import Then
 
+/// 모달뷰에서 금액을 입력하는 공용 컴포넌츠
 final class ModalAmoutView: UIView {
+    
+    // MARK: - UI Components
     
     private let title = UILabel().then {
         $0.text = "금액"
@@ -48,6 +51,8 @@ final class ModalAmoutView: UIView {
         $0.keyboardType = .numberPad
     }
     
+    // MARK: - Initializer
+    
     override init(frame: CGRect) {
         super.init(frame: frame)
         
@@ -58,6 +63,7 @@ final class ModalAmoutView: UIView {
         fatalError("init(coder:) has not been implemented")
     }
     
+    // 앱의 라이트모드/다크모드가 변경 되었을 때 이를 감지하여 CALayer의 컬러를 재정의 해주는 메소드
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
         if traitCollection.hasDifferentColorAppearance(comparedTo: previousTraitCollection) {
@@ -65,12 +71,18 @@ final class ModalAmoutView: UIView {
         }
     }
     
+    /// 금액 입력 뷰를 세팅하는 메소드
+    /// - Parameters:
+    ///   - amout: 금액(빈 값일 수도 있음)
+    ///   - currency: 통화
     func configtAmoutView(amout: Int?, currency: Currency) {
         self.textField.text = "\(amout ?? 0)"
         self.currencyButton.setTitle(currency.rawValue, for: .normal)
     }
     
 }
+
+// MARK: - UI Setting Method
 
 private extension ModalAmoutView {
     
@@ -85,6 +97,7 @@ private extension ModalAmoutView {
         [title, currencyButton, textField].forEach { self.addSubview($0) }
     }
     
+    /// 통화 선택 버튼에 메뉴 뷰를 추가하는 메소드
     func configureMenuForButton() {
         // 메뉴 항목 생성
         let children: [UIAction] = {

--- a/TripLog/TripLog/Feat-Crois/ModalViewController/View/ModalAmoutView.swift
+++ b/TripLog/TripLog/Feat-Crois/ModalViewController/View/ModalAmoutView.swift
@@ -75,7 +75,7 @@ final class ModalAmoutView: UIView {
     /// - Parameters:
     ///   - amout: 금액(빈 값일 수도 있음)
     ///   - currency: 통화
-    func configtAmoutView(amout: Int?, currency: Currency) {
+    func configureAmoutView(amout: Int?, currency: Currency) {
         self.textField.text = "\(amout ?? 0)"
         self.currencyButton.setTitle(currency.rawValue, for: .normal)
     }

--- a/TripLog/TripLog/Feat-Crois/ModalViewController/View/ModalAmoutView.swift
+++ b/TripLog/TripLog/Feat-Crois/ModalViewController/View/ModalAmoutView.swift
@@ -65,6 +65,11 @@ final class ModalAmoutView: UIView {
         }
     }
     
+    func configtAmoutView(amout: Int?, currency: Currency) {
+        self.textField.text = "\(amout ?? 0)"
+        self.currencyButton.setTitle(currency.rawValue, for: .normal)
+    }
+    
 }
 
 private extension ModalAmoutView {

--- a/TripLog/TripLog/Feat-Crois/ModalViewController/View/ModalAmoutView.swift
+++ b/TripLog/TripLog/Feat-Crois/ModalViewController/View/ModalAmoutView.swift
@@ -1,0 +1,116 @@
+//
+//  ModalAmoutView.swift
+//  TripLog
+//
+//  Created by 장상경 on 1/21/25.
+//
+
+import UIKit
+import SnapKit
+import Then
+
+final class ModalAmoutView: UIView {
+    
+    private let title = UILabel().then {
+        $0.text = "금액"
+        $0.font = UIFont.SCDream(size: .headline, weight: .medium)
+        $0.numberOfLines = 1
+        $0.textColor = UIColor.Dark.base
+        $0.textAlignment = .left
+        $0.backgroundColor = .clear
+    }
+    
+    private let currencyButton = UIButton().then {
+        $0.setTitle("원(한화)", for: .normal)
+        $0.setTitleColor(UIColor.Personal.normal, for: .normal)
+        $0.titleLabel?.font = UIFont.SCDream(size: .headline, weight: .medium)
+        $0.setImage(UIImage(systemName: "chevron.up.chevron.down"), for: .normal)
+        $0.semanticContentAttribute = .forceRightToLeft
+        $0.tintColor = UIColor.Personal.normal
+        $0.backgroundColor = .clear
+    }
+    
+    private let textField = UITextField().then {
+        $0.setPlaceholder(title: "0", color: .Light.r400)
+        $0.font = UIFont.SCDream(size: .body, weight: .regular)
+        $0.textColor = UIColor.Dark.base
+        $0.borderStyle = .none
+        $0.clipsToBounds = true
+        $0.backgroundColor = .clear
+        $0.layer.cornerRadius = 8
+        $0.layer.borderColor = UIColor.Dark.base.withAlphaComponent(0.1).cgColor
+        $0.layer.borderWidth = 1
+        $0.leftView = UIView(frame: .init(x: 0, y: 0, width: 12, height: 12))
+        $0.leftViewMode = .always
+        $0.rightView = UIView(frame: .init(x: 0, y: 0, width: 12, height: 12))
+        $0.rightViewMode = .always
+        $0.autocapitalizationType = .none
+        $0.keyboardType = .numberPad
+    }
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        setupUI()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+}
+
+private extension ModalAmoutView {
+    
+    func setupUI() {
+        configureSelf()
+        setupLayout()
+        configureMenuForButton()
+    }
+    
+    func configureSelf() {
+        self.backgroundColor = .clear
+        [title, currencyButton, textField].forEach { self.addSubview($0) }
+    }
+    
+    func configureMenuForButton() {
+        // 메뉴 항목 생성
+        let children: [UIAction] = {
+            var childrens: [UIAction] = []
+            
+            Currency.allCurrencies.forEach { currency in
+                let action = UIAction(title: currency, handler: { [weak self] _ in
+                    self?.currencyButton.setTitle(currency, for: .normal)
+                })
+                childrens.append(action)
+            }
+            return childrens
+        }()
+        
+        // UIMenu 생성
+        let menu = UIMenu(title: "환율 선택", options: .displayInline, children: children)
+        
+        // UIButton에 메뉴 연결
+        currencyButton.menu = menu
+        currencyButton.showsMenuAsPrimaryAction = true // 버튼 클릭 시 메뉴 표시
+    }
+    
+    func setupLayout() {
+        title.snp.makeConstraints {
+            $0.top.leading.equalToSuperview()
+            $0.height.equalTo(16)
+        }
+        
+        currencyButton.snp.makeConstraints {
+            $0.top.trailing.equalToSuperview()
+            $0.height.equalTo(title)
+        }
+        
+        textField.snp.makeConstraints {
+            $0.top.equalTo(title.snp.bottom).offset(8)
+            $0.horizontalEdges.equalToSuperview()
+            $0.bottom.equalToSuperview()
+        }
+    }
+    
+}

--- a/TripLog/TripLog/Feat-Crois/ModalViewController/View/ModalButtons.swift
+++ b/TripLog/TripLog/Feat-Crois/ModalViewController/View/ModalButtons.swift
@@ -52,6 +52,13 @@ final class ModalButtons: UIView {
         fatalError("init(coder:) has not been implemented")
     }
     
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+        if traitCollection.hasDifferentColorAppearance(comparedTo: previousTraitCollection) {
+            self.cancelButton.layer.borderColor = UIColor.Dark.base.withAlphaComponent(0.1).cgColor
+        }
+    }
+    
 }
 
 private extension ModalButtons {

--- a/TripLog/TripLog/Feat-Crois/ModalViewController/View/ModalButtons.swift
+++ b/TripLog/TripLog/Feat-Crois/ModalViewController/View/ModalButtons.swift
@@ -1,0 +1,77 @@
+//
+//  ModalButtons.swift
+//  TripLog
+//
+//  Created by 장상경 on 1/20/25.
+//
+
+import UIKit
+import SnapKit
+import Then
+
+final class ModalButtons: UIView {
+    
+    private(set) var cancelButton = UIButton().then {
+        $0.setTitle("취소", for: .normal)
+        $0.setTitleColor(UIColor.Dark.base, for: .normal)
+        $0.titleLabel?.font = .SCDream(size: .headline, weight: .medium)
+        $0.titleLabel?.numberOfLines = 1
+        $0.titleLabel?.textAlignment = .center
+        $0.backgroundColor = .clear
+        $0.layer.cornerRadius = 8
+        $0.layer.borderColor = UIColor.Light.r400.cgColor
+        $0.layer.borderWidth = 1
+    }
+    
+    private(set) var createButton = UIButton().then {
+        $0.titleLabel?.font = .SCDream(size: .headline, weight: .medium)
+        $0.setTitleColor(.white, for: .normal)
+        $0.titleLabel?.numberOfLines = 1
+        $0.titleLabel?.textAlignment = .center
+        $0.backgroundColor = .Personal.normal
+        $0.layer.cornerRadius = 8
+    }
+    
+    private lazy var buttonStack = UIStackView().then {
+        $0.axis = .horizontal
+        $0.distribution = .fillEqually
+        $0.alignment = .fill
+        $0.spacing = 16
+    }
+    
+    init(buttonTitle: String) {
+        super.init(frame: .zero)
+        
+        self.createButton.setTitle(buttonTitle, for: .normal)
+        setupUI()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+}
+
+private extension ModalButtons {
+    
+    func setupUI() {
+        configureSelf()
+        setupStackView()
+        setupLayout()
+    }
+    
+    func configureSelf() {
+        self.backgroundColor = .clear
+        self.addSubview(buttonStack)
+    }
+    
+    func setupStackView() {
+        [cancelButton, createButton].forEach { self.buttonStack.addArrangedSubview($0) }
+    }
+    
+    func setupLayout() {
+        buttonStack.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+        }
+    }
+}

--- a/TripLog/TripLog/Feat-Crois/ModalViewController/View/ModalButtons.swift
+++ b/TripLog/TripLog/Feat-Crois/ModalViewController/View/ModalButtons.swift
@@ -8,10 +8,12 @@
 import UIKit
 import SnapKit
 import Then
+import RxSwift
+import RxCocoa
 
 final class ModalButtons: UIView {
     
-    private(set) var cancelButton = UIButton().then {
+    fileprivate let cancelButton = UIButton().then {
         $0.setTitle("취소", for: .normal)
         $0.setTitleColor(UIColor.Dark.base, for: .normal)
         $0.titleLabel?.font = .SCDream(size: .headline, weight: .medium)
@@ -23,7 +25,7 @@ final class ModalButtons: UIView {
         $0.layer.borderWidth = 1
     }
     
-    private(set) var createButton = UIButton().then {
+    fileprivate let createButton = UIButton().then {
         $0.titleLabel?.font = .SCDream(size: .headline, weight: .medium)
         $0.setTitleColor(.white, for: .normal)
         $0.titleLabel?.numberOfLines = 1
@@ -73,5 +75,15 @@ private extension ModalButtons {
         buttonStack.snp.makeConstraints {
             $0.edges.equalToSuperview()
         }
+    }
+}
+
+extension Reactive where Base: ModalButtons {
+    var activeButtondTapped: Observable<Void> {
+        return base.createButton.rx.tap.asObservable()
+    }
+    
+    var cancelButtondTapped: Observable<Void> {
+        return base.cancelButton.rx.tap.asObservable()
     }
 }

--- a/TripLog/TripLog/Feat-Crois/ModalViewController/View/ModalButtons.swift
+++ b/TripLog/TripLog/Feat-Crois/ModalViewController/View/ModalButtons.swift
@@ -11,7 +11,10 @@ import Then
 import RxSwift
 import RxCocoa
 
+/// 모달에서 버튼을 구현한 공용 컴포넌츠
 final class ModalButtons: UIView {
+    
+    // MARK: - UI Components
     
     fileprivate let cancelButton = UIButton().then {
         $0.setTitle("취소", for: .normal)
@@ -41,6 +44,8 @@ final class ModalButtons: UIView {
         $0.spacing = 16
     }
     
+    // MARK: - Initializer
+    
     init(buttonTitle: String) {
         super.init(frame: .zero)
         
@@ -52,6 +57,7 @@ final class ModalButtons: UIView {
         fatalError("init(coder:) has not been implemented")
     }
     
+    // 앱의 라이트모드/다크모드가 변경 되었을 때 이를 감지하여 CALayer의 컬러를 재정의 해주는 메소드
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
         if traitCollection.hasDifferentColorAppearance(comparedTo: previousTraitCollection) {
@@ -60,6 +66,8 @@ final class ModalButtons: UIView {
     }
     
 }
+
+// MARK: - UI Setting Method
 
 private extension ModalButtons {
     
@@ -85,11 +93,15 @@ private extension ModalButtons {
     }
 }
 
+// MARK: - Reactive Extension
+
 extension Reactive where Base: ModalButtons {
+    /// active 버튼을 클릭했을 때 이벤트를 방출하는 옵저버블
     var activeButtondTapped: Observable<Void> {
         return base.createButton.rx.tap.asObservable()
     }
     
+    /// cancel 버튼을 클릭했을 때 이벤트를 방출하는 옵저버블
     var cancelButtondTapped: Observable<Void> {
         return base.cancelButton.rx.tap.asObservable()
     }

--- a/TripLog/TripLog/Feat-Crois/ModalViewController/View/ModalButtons.swift
+++ b/TripLog/TripLog/Feat-Crois/ModalViewController/View/ModalButtons.swift
@@ -19,7 +19,7 @@ final class ModalButtons: UIView {
         $0.titleLabel?.textAlignment = .center
         $0.backgroundColor = .clear
         $0.layer.cornerRadius = 8
-        $0.layer.borderColor = UIColor.Light.r400.cgColor
+        $0.layer.borderColor = UIColor.Dark.base.withAlphaComponent(0.1).cgColor
         $0.layer.borderWidth = 1
     }
     

--- a/TripLog/TripLog/Feat-Crois/ModalViewController/View/ModalDatePicker.swift
+++ b/TripLog/TripLog/Feat-Crois/ModalViewController/View/ModalDatePicker.swift
@@ -11,8 +11,11 @@ import Then
 import RxSwift
 import RxCocoa
 
+/// 모달뷰에서 날짜를 선택하는 공용 컴포넌츠
 final class ModalDatePicker: UIView {
-        
+    
+    // MARK: - UI Components
+    
     fileprivate let datePicker = UIDatePicker().then {
         $0.datePickerMode = .date
         $0.preferredDatePickerStyle = .compact
@@ -46,6 +49,10 @@ final class ModalDatePicker: UIView {
         $0.contentMode = .scaleAspectFit
     }
     
+    // MARK: - Initializer
+    
+    /// 데이트픽커뷰의 기본 생성자
+    /// - Parameter direction: 데이트 픽커의 방향(방향에 따라 cornerRadius 값이 바뀜)
     init(direction: ModalDatePickerDirection) {
         super.init(frame: .zero)
         
@@ -65,6 +72,7 @@ final class ModalDatePicker: UIView {
         fatalError("init(coder:) has not been implemented")
     }
     
+    // 앱의 라이트모드/다크모드가 변경 되었을 때 이를 감지하여 CALayer의 컬러를 재정의 해주는 메소드
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
         if traitCollection.hasDifferentColorAppearance(comparedTo: previousTraitCollection) {
@@ -72,6 +80,8 @@ final class ModalDatePicker: UIView {
         }
     }
     
+    /// 데이트픽커 뷰의 날짜를 설정하는 메소드
+    /// - Parameter date: 입력할 날짜
     func configTextField(date: Date) {
         let formatter = DateFormatter()
         formatter.dateFormat = "yyyy년 MM월 dd일"
@@ -80,6 +90,8 @@ final class ModalDatePicker: UIView {
     }
     
 }
+
+// MARK: - UI Setting Method
 
 private extension ModalDatePicker {
     
@@ -111,7 +123,10 @@ private extension ModalDatePicker {
     
 }
 
+// MARK: - Reactive Extension
+
 extension Reactive where Base: ModalDatePicker {
+    /// 데이트픽커의 날짜가 선택되면 해당 날짜를 이벤트로 방출하는 옵저버블
     var selectedDate: Observable<Date> {
         return base.datePicker.rx.date.asObservable()
     }

--- a/TripLog/TripLog/Feat-Crois/ModalViewController/View/ModalDatePicker.swift
+++ b/TripLog/TripLog/Feat-Crois/ModalViewController/View/ModalDatePicker.swift
@@ -8,12 +8,17 @@
 import UIKit
 import SnapKit
 import Then
+import RxSwift
+import RxCocoa
 
 final class ModalDatePicker: UIView {
+    
+    private let disposeBag = DisposeBag()
     
     private let datePicker = UIDatePicker().then {
         $0.datePickerMode = .date
         $0.preferredDatePickerStyle = .compact
+        $0.locale = .init(identifier: "KO_kr")
     }
     
     private let textField = UITextField().then {
@@ -69,6 +74,7 @@ private extension ModalDatePicker {
     func setupUI() {
         configureSelf()
         setupLayout()
+        bind()
     }
     
     func configureSelf() {
@@ -90,6 +96,19 @@ private extension ModalDatePicker {
             $0.centerY.equalToSuperview()
             $0.width.height.equalTo(20)
         }
+    }
+    
+    func bind() {
+        datePicker.rx.date
+            .skip(1)
+            .distinctUntilChanged()
+            .map { date -> String in
+                let formatter = DateFormatter()
+                formatter.dateFormat = "yyyy년 MM월 dd일"
+                return formatter.string(from: date)
+            }
+            .bind(to: textField.rx.text)
+            .disposed(by: disposeBag)
     }
     
 }

--- a/TripLog/TripLog/Feat-Crois/ModalViewController/View/ModalDatePicker.swift
+++ b/TripLog/TripLog/Feat-Crois/ModalViewController/View/ModalDatePicker.swift
@@ -82,7 +82,7 @@ final class ModalDatePicker: UIView {
     
     /// 데이트픽커 뷰의 날짜를 설정하는 메소드
     /// - Parameter date: 입력할 날짜
-    func configTextField(date: Date) {
+    func configureTextField(date: Date) {
         let formatter = DateFormatter()
         formatter.dateFormat = "yyyy년 MM월 dd일"
         

--- a/TripLog/TripLog/Feat-Crois/ModalViewController/View/ModalDatePicker.swift
+++ b/TripLog/TripLog/Feat-Crois/ModalViewController/View/ModalDatePicker.swift
@@ -51,7 +51,7 @@ final class ModalDatePicker: UIView {
     
     // MARK: - Initializer
     
-    /// 데이트픽커뷰의 기본 생성자
+    /// DatePicker뷰의 기본 생성자
     /// - Parameter direction: 데이트 픽커의 방향(방향에 따라 cornerRadius 값이 바뀜)
     init(direction: ModalDatePickerDirection) {
         super.init(frame: .zero)
@@ -80,7 +80,7 @@ final class ModalDatePicker: UIView {
         }
     }
     
-    /// 데이트픽커 뷰의 날짜를 설정하는 메소드
+    /// DatePicker 뷰의 날짜를 설정하는 메소드
     /// - Parameter date: 입력할 날짜
     func configureTextField(date: Date) {
         let formatter = DateFormatter()
@@ -126,7 +126,7 @@ private extension ModalDatePicker {
 // MARK: - Reactive Extension
 
 extension Reactive where Base: ModalDatePicker {
-    /// 데이트픽커의 날짜가 선택되면 해당 날짜를 이벤트로 방출하는 옵저버블
+    /// DatePicker의 날짜가 선택되면 해당 날짜를 이벤트로 방출하는 옵저버블
     var selectedDate: Observable<Date> {
         return base.datePicker.rx.date.asObservable()
     }

--- a/TripLog/TripLog/Feat-Crois/ModalViewController/View/ModalDatePicker.swift
+++ b/TripLog/TripLog/Feat-Crois/ModalViewController/View/ModalDatePicker.swift
@@ -12,10 +12,8 @@ import RxSwift
 import RxCocoa
 
 final class ModalDatePicker: UIView {
-    
-    private let disposeBag = DisposeBag()
-    
-    private let datePicker = UIDatePicker().then {
+        
+    fileprivate let datePicker = UIDatePicker().then {
         $0.datePickerMode = .date
         $0.preferredDatePickerStyle = .compact
         $0.locale = .init(identifier: "KO_kr")
@@ -67,6 +65,13 @@ final class ModalDatePicker: UIView {
         fatalError("init(coder:) has not been implemented")
     }
     
+    func configTextField(date: Date) {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy년 MM월 dd일"
+        
+        self.textField.text = formatter.string(from: date)
+    }
+    
 }
 
 private extension ModalDatePicker {
@@ -74,7 +79,6 @@ private extension ModalDatePicker {
     func setupUI() {
         configureSelf()
         setupLayout()
-        bind()
     }
     
     func configureSelf() {
@@ -98,18 +102,10 @@ private extension ModalDatePicker {
         }
     }
     
-    func bind() {
-        datePicker.rx.date
-            .skip(1)
-            .distinctUntilChanged()
-            .map { date -> String in
-                let formatter = DateFormatter()
-                formatter.dateFormat = "yyyy년 MM월 dd일"
-                return formatter.string(from: date)
-            }
-            .bind(to: textField.rx.text)
-            .disposed(by: disposeBag)
-    }
-    
 }
 
+extension Reactive where Base: ModalDatePicker {
+    var selectedDate: Observable<Date> {
+        return base.datePicker.rx.date.asObservable()
+    }
+}

--- a/TripLog/TripLog/Feat-Crois/ModalViewController/View/ModalDatePicker.swift
+++ b/TripLog/TripLog/Feat-Crois/ModalViewController/View/ModalDatePicker.swift
@@ -65,6 +65,13 @@ final class ModalDatePicker: UIView {
         fatalError("init(coder:) has not been implemented")
     }
     
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+        if traitCollection.hasDifferentColorAppearance(comparedTo: previousTraitCollection) {
+            self.textField.layer.borderColor = UIColor.Dark.base.withAlphaComponent(0.1).cgColor
+        }
+    }
+    
     func configTextField(date: Date) {
         let formatter = DateFormatter()
         formatter.dateFormat = "yyyy년 MM월 dd일"

--- a/TripLog/TripLog/Feat-Crois/ModalViewController/View/ModalDatePicker.swift
+++ b/TripLog/TripLog/Feat-Crois/ModalViewController/View/ModalDatePicker.swift
@@ -1,0 +1,96 @@
+//
+//  ModalDataPicker.swift
+//  TripLog
+//
+//  Created by 장상경 on 1/20/25.
+//
+
+import UIKit
+import SnapKit
+import Then
+
+final class ModalDatePicker: UIView {
+    
+    private let datePicker = UIDatePicker().then {
+        $0.datePickerMode = .date
+        $0.preferredDatePickerStyle = .compact
+    }
+    
+    private let textField = UITextField().then {
+        $0.setPlaceholder(title: "mm/dd/yyyy", color: .Light.r400)
+        $0.font = UIFont.SCDream(size: .body, weight: .regular)
+        $0.textColor = UIColor.Dark.base
+        $0.borderStyle = .none
+        $0.clipsToBounds = true
+        $0.backgroundColor = UIColor.Light.base
+        $0.layer.cornerRadius = 8
+        $0.layer.masksToBounds = true
+        $0.layer.borderColor = UIColor.Dark.base.withAlphaComponent(0.1).cgColor
+        $0.layer.borderWidth = 1
+        $0.leftView = UIView(frame: .init(x: 0, y: 0, width: 12, height: 12))
+        $0.leftViewMode = .always
+        $0.rightView = UIView(frame: .init(x: 0, y: 0, width: 12, height: 12))
+        $0.rightViewMode = .always
+        $0.autocapitalizationType = .none
+        $0.keyboardType = .default
+        $0.isEnabled = false
+    }
+    
+    private let calendarView = UIImageView().then {
+        $0.image = UIImage(systemName: "calendar")
+        $0.tintColor = .Dark.base
+        $0.backgroundColor = .clear
+        $0.contentMode = .scaleAspectFit
+    }
+    
+    init(direction: ModalDatePickerDirection) {
+        super.init(frame: .zero)
+        
+        setupUI()
+        switch direction {
+        case .right:
+            textField.layer.maskedCorners = [.layerMaxXMinYCorner
+                                      , .layerMaxXMaxYCorner]
+            
+        case .left:
+            textField.layer.maskedCorners = [.layerMinXMinYCorner
+                                      , .layerMinXMaxYCorner]
+        }
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+}
+
+private extension ModalDatePicker {
+    
+    func setupUI() {
+        configureSelf()
+        setupLayout()
+    }
+    
+    func configureSelf() {
+        self.backgroundColor = .clear
+        [datePicker, textField, calendarView].forEach { self.addSubview($0) }
+    }
+    
+    func setupLayout() {
+        datePicker.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+        }
+        
+        textField.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+        }
+        
+        calendarView.snp.makeConstraints {
+            $0.trailing.equalToSuperview().inset(12)
+            $0.centerY.equalToSuperview()
+            $0.width.height.equalTo(20)
+        }
+    }
+    
+}
+

--- a/TripLog/TripLog/Feat-Crois/ModalViewController/View/ModalDateView.swift
+++ b/TripLog/TripLog/Feat-Crois/ModalViewController/View/ModalDateView.swift
@@ -31,7 +31,7 @@ final class ModalDateView: UIView {
         $0.axis = .horizontal
         $0.distribution = .fillEqually
         $0.alignment = .fill
-        $0.spacing = 0
+        $0.spacing = -0.5
         $0.backgroundColor = .clear
     }
     

--- a/TripLog/TripLog/Feat-Crois/ModalViewController/View/ModalDateView.swift
+++ b/TripLog/TripLog/Feat-Crois/ModalViewController/View/ModalDateView.swift
@@ -92,7 +92,7 @@ private extension ModalDateView {
         }
     }
     
-    /// 데이트픽커 바인딩 메소드
+    /// DatePicker 바인딩 메소드
     func bind() {
         startDatePicker.rx.selectedDate
             .skip(1)

--- a/TripLog/TripLog/Feat-Crois/ModalViewController/View/ModalDateView.swift
+++ b/TripLog/TripLog/Feat-Crois/ModalViewController/View/ModalDateView.swift
@@ -11,9 +11,14 @@ import Then
 import RxSwift
 import RxCocoa
 
+/// 모달뷰에서 날짜 설정을 구현한 공용 컴포넌츠
 final class ModalDateView: UIView {
     
+    // MARK: - Rx Properties
+    
     private let disposeBag = DisposeBag()
+    
+    // MARK: - UI Components
     
     private let title = UILabel().then {
         $0.text = "여행 일정"
@@ -35,8 +40,12 @@ final class ModalDateView: UIView {
         $0.backgroundColor = .clear
     }
     
-    private var startDate: Date?
-    private var endDate: Date?
+    // MARK: - Properties
+    
+    private var startDate: Date? // 여행 시작 일정을 저장
+    private var endDate: Date? // 여행 종료 일정을 저장
+    
+    // MARK: - Initializer
     
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -48,6 +57,8 @@ final class ModalDateView: UIView {
         fatalError("init(coder:) has not been implemented")
     }
 }
+
+// MARK: - UI Setting Method
 
 private extension ModalDateView {
     
@@ -81,6 +92,7 @@ private extension ModalDateView {
         }
     }
     
+    /// 데이트픽커 바인딩 메소드
     func bind() {
         startDatePicker.rx.selectedDate
             .skip(2)

--- a/TripLog/TripLog/Feat-Crois/ModalViewController/View/ModalDateView.swift
+++ b/TripLog/TripLog/Feat-Crois/ModalViewController/View/ModalDateView.swift
@@ -95,7 +95,7 @@ private extension ModalDateView {
     /// 데이트픽커 바인딩 메소드
     func bind() {
         startDatePicker.rx.selectedDate
-            .skip(2)
+            .skip(1)
             .asSignal(onErrorSignalWith: .empty())
             .distinctUntilChanged()
             .withUnretained(self)
@@ -103,6 +103,13 @@ private extension ModalDateView {
                 
                 owner.startDate = date
                 owner.startDatePicker.configTextField(date: date)
+                
+                guard let endDate = owner.endDate,
+                      endDate < date
+                else { return }
+                
+                owner.endDate = date
+                owner.endDatePicker.configTextField(date: date)
                 
             }.disposed(by: disposeBag)
         

--- a/TripLog/TripLog/Feat-Crois/ModalViewController/View/ModalDateView.swift
+++ b/TripLog/TripLog/Feat-Crois/ModalViewController/View/ModalDateView.swift
@@ -1,0 +1,76 @@
+//
+//  ModalDateView.swift
+//  TripLog
+//
+//  Created by 장상경 on 1/21/25.
+//
+
+import UIKit
+import SnapKit
+import Then
+
+final class ModalDateView: UIView {
+    
+    private let title = UILabel().then {
+        $0.text = "여행 일정"
+        $0.font = UIFont.SCDream(size: .headline, weight: .medium)
+        $0.numberOfLines = 1
+        $0.textColor = UIColor.Dark.base
+        $0.textAlignment = .left
+        $0.backgroundColor = .clear
+    }
+    
+    private let startDatePicker = ModalDatePicker(direction: .left)
+    private let endDatePicker = ModalDatePicker(direction: .right)
+    
+    private let datePickerStack = UIStackView().then {
+        $0.axis = .horizontal
+        $0.distribution = .fillEqually
+        $0.alignment = .fill
+        $0.spacing = 0
+        $0.backgroundColor = .clear
+    }
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        setupUI()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+private extension ModalDateView {
+    
+    func setupUI() {
+        configureSelf()
+        setupStackView()
+        setupLayout()
+    }
+    
+    func configureSelf() {
+        self.backgroundColor = .clear
+        [title, datePickerStack].forEach { self.addSubview($0) }
+    }
+    
+    func setupStackView() {
+        [startDatePicker, endDatePicker].forEach {
+            self.datePickerStack.addArrangedSubview($0)
+        }
+    }
+    
+    func setupLayout() {
+        title.snp.makeConstraints {
+            $0.top.leading.equalToSuperview()
+            $0.height.equalTo(16)
+        }
+        
+        datePickerStack.snp.makeConstraints {
+            $0.top.equalTo(title.snp.bottom).offset(8)
+            $0.bottom.horizontalEdges.equalToSuperview()
+        }
+    }
+    
+}

--- a/TripLog/TripLog/Feat-Crois/ModalViewController/View/ModalDateView.swift
+++ b/TripLog/TripLog/Feat-Crois/ModalViewController/View/ModalDateView.swift
@@ -102,14 +102,14 @@ private extension ModalDateView {
             .emit { owner, date in
                 
                 owner.startDate = date
-                owner.startDatePicker.configTextField(date: date)
+                owner.startDatePicker.configureTextField(date: date)
                 
                 guard let endDate = owner.endDate,
                       endDate < date
                 else { return }
                 
                 owner.endDate = date
-                owner.endDatePicker.configTextField(date: date)
+                owner.endDatePicker.configureTextField(date: date)
                 
             }.disposed(by: disposeBag)
         
@@ -121,14 +121,14 @@ private extension ModalDateView {
             .emit { owner, date in
                 
                 owner.endDate = date
-                owner.endDatePicker.configTextField(date: date)
+                owner.endDatePicker.configureTextField(date: date)
                 
                 guard let startDate = owner.startDate,
                       startDate > date
                 else { return }
                 
                 owner.startDate = date
-                owner.startDatePicker.configTextField(date: date)
+                owner.startDatePicker.configureTextField(date: date)
                 
             }.disposed(by: disposeBag)
     }

--- a/TripLog/TripLog/Feat-Crois/ModalViewController/View/ModalSegmentView.swift
+++ b/TripLog/TripLog/Feat-Crois/ModalViewController/View/ModalSegmentView.swift
@@ -40,7 +40,7 @@ final class ModalSegmentView: UIView {
     
     /// 세크먼트 컨트롤의 인덱스를 설정하는 메소드
     /// - Parameter isCardPayment: 지불 방법이 카드인지 확인하는 Bool 데이터
-    func configSegment(to isCardPayment: Bool) {
+    func configureSegment(to isCardPayment: Bool) {
         self.segmentView.selectedSegmentIndex = isCardPayment ? 1 : 0
     }
     

--- a/TripLog/TripLog/Feat-Crois/ModalViewController/View/ModalSegmentView.swift
+++ b/TripLog/TripLog/Feat-Crois/ModalViewController/View/ModalSegmentView.swift
@@ -1,0 +1,64 @@
+//
+//  ModalSegmentView.swift
+//  TripLog
+//
+//  Created by 장상경 on 1/21/25.
+//
+
+import UIKit
+import SnapKit
+import Then
+
+final class ModalSegmentView: UIView {
+    
+    private let title = UILabel().then {
+        $0.text = "지불 방법"
+        $0.font = UIFont.SCDream(size: .headline, weight: .medium)
+        $0.numberOfLines = 1
+        $0.textColor = UIColor.Dark.base
+        $0.textAlignment = .left
+        $0.backgroundColor = .clear
+    }
+    
+    private let segmentView = UISegmentedControl(items: ["현금", "카드"]).then {
+        $0.selectedSegmentIndex = 0
+    }
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        setupUI()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+}
+
+private extension ModalSegmentView {
+    
+    func setupUI() {
+        configureSelf()
+        setupLayout()
+    }
+    
+    func configureSelf() {
+        self.backgroundColor = .clear
+        [title, segmentView].forEach { self.addSubview($0) }
+    }
+    
+    func setupLayout() {
+        title.snp.makeConstraints {
+            $0.top.leading.equalToSuperview()
+            $0.height.equalTo(16)
+        }
+        
+        segmentView.snp.makeConstraints {
+            $0.top.equalTo(title.snp.bottom).offset(8)
+            $0.horizontalEdges.equalToSuperview()
+            $0.bottom.equalToSuperview()
+        }
+    }
+    
+}

--- a/TripLog/TripLog/Feat-Crois/ModalViewController/View/ModalSegmentView.swift
+++ b/TripLog/TripLog/Feat-Crois/ModalViewController/View/ModalSegmentView.swift
@@ -34,6 +34,10 @@ final class ModalSegmentView: UIView {
         fatalError("init(coder:) has not been implemented")
     }
     
+    func configSegment(to isCardPayment: Bool) {
+        self.segmentView.selectedSegmentIndex = isCardPayment ? 1 : 0
+    }
+    
 }
 
 private extension ModalSegmentView {

--- a/TripLog/TripLog/Feat-Crois/ModalViewController/View/ModalSegmentView.swift
+++ b/TripLog/TripLog/Feat-Crois/ModalViewController/View/ModalSegmentView.swift
@@ -9,7 +9,10 @@ import UIKit
 import SnapKit
 import Then
 
+/// 모달뷰에서 카드, 현금을 선택하는 세그먼트 컨트롤 공용 컴포넌츠
 final class ModalSegmentView: UIView {
+    
+    // MARK: - UI Components
     
     private let title = UILabel().then {
         $0.text = "지불 방법"
@@ -24,6 +27,7 @@ final class ModalSegmentView: UIView {
         $0.selectedSegmentIndex = 0
     }
     
+    // MARK: - Initializer
     override init(frame: CGRect) {
         super.init(frame: frame)
         
@@ -34,11 +38,15 @@ final class ModalSegmentView: UIView {
         fatalError("init(coder:) has not been implemented")
     }
     
+    /// 세크먼트 컨트롤의 인덱스를 설정하는 메소드
+    /// - Parameter isCardPayment: 지불 방법이 카드인지 확인하는 Bool 데이터
     func configSegment(to isCardPayment: Bool) {
         self.segmentView.selectedSegmentIndex = isCardPayment ? 1 : 0
     }
     
 }
+
+// MARK: - UI Setting Method
 
 private extension ModalSegmentView {
     

--- a/TripLog/TripLog/Feat-Crois/ModalViewController/View/ModalTextField.swift
+++ b/TripLog/TripLog/Feat-Crois/ModalViewController/View/ModalTextField.swift
@@ -1,0 +1,91 @@
+//
+//  ModalTextField.swift
+//  TripLog
+//
+//  Created by 장상경 on 1/20/25.
+//
+
+import UIKit
+import SnapKit
+import Then
+
+final class ModalTextField: UIView {
+    
+    private let title = UILabel().then {
+        $0.font = UIFont.SCDream(size: .headline, weight: .medium)
+        $0.numberOfLines = 1
+        $0.textColor = UIColor.Dark.base
+        $0.textAlignment = .left
+        $0.backgroundColor = .clear
+    }
+    
+    private let subTitle = UILabel().then {
+        $0.font = UIFont.SCDream(size: .headline, weight: .medium)
+        $0.numberOfLines = 1
+        $0.textColor = UIColor.Personal.normal
+        $0.textAlignment = .right
+        $0.backgroundColor = .clear
+    }
+    
+    private let textField = UITextField().then {
+        $0.font = UIFont.SCDream(size: .body, weight: .regular)
+        $0.textColor = UIColor.Dark.base
+        $0.borderStyle = .none
+        $0.clipsToBounds = true
+        $0.backgroundColor = .clear
+        $0.layer.cornerRadius = 8
+        $0.layer.borderColor = UIColor.Light.r400.cgColor
+        $0.layer.borderWidth = 1
+        $0.leftView = UIView(frame: .init(x: 0, y: 0, width: 10, height: 10))
+        $0.leftViewMode = .always
+        $0.rightView = UIView(frame: .init(x: 0, y: 0, width: 10, height: 10))
+        $0.rightViewMode = .always
+        $0.autocapitalizationType = .none
+        $0.keyboardType = .default
+    }
+    
+    init(title: String, subTitle: String?, placeholder: String) {
+        super.init(frame: .zero)
+        
+        self.title.text = title
+        self.subTitle.text = subTitle
+        self.textField.setPlaceholder(title: placeholder, color: .Light.r400)
+        setupUI()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+}
+
+private extension ModalTextField {
+    
+    func setupUI() {
+        configureSelf()
+        setupLayout()
+    }
+    
+    func configureSelf() {
+        self.backgroundColor = .clear
+        [title, subTitle, textField].forEach { self.addSubview($0) }
+    }
+    
+    func setupLayout() {
+        title.snp.makeConstraints {
+            $0.top.leading.equalToSuperview()
+            $0.height.equalTo(16)
+        }
+        
+        subTitle.snp.makeConstraints {
+            $0.top.trailing.equalToSuperview()
+            $0.height.equalTo(title)
+        }
+        
+        textField.snp.makeConstraints {
+            $0.top.equalTo(title.snp.bottom).offset(8)
+            $0.horizontalEdges.equalToSuperview()
+            $0.bottom.equalToSuperview()
+        }
+    }
+}

--- a/TripLog/TripLog/Feat-Crois/ModalViewController/View/ModalTextField.swift
+++ b/TripLog/TripLog/Feat-Crois/ModalViewController/View/ModalTextField.swift
@@ -57,6 +57,13 @@ final class ModalTextField: UIView {
         fatalError("init(coder:) has not been implemented")
     }
     
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+        if traitCollection.hasDifferentColorAppearance(comparedTo: previousTraitCollection) {
+            self.textField.layer.borderColor = UIColor.Dark.base.withAlphaComponent(0.1).cgColor
+        }
+    }
+    
     func changeKeyboardType(type: UIKeyboardType) {
         self.textField.keyboardType = type
     }

--- a/TripLog/TripLog/Feat-Crois/ModalViewController/View/ModalTextField.swift
+++ b/TripLog/TripLog/Feat-Crois/ModalViewController/View/ModalTextField.swift
@@ -34,11 +34,11 @@ final class ModalTextField: UIView {
         $0.clipsToBounds = true
         $0.backgroundColor = .clear
         $0.layer.cornerRadius = 8
-        $0.layer.borderColor = UIColor.Light.r400.cgColor
+        $0.layer.borderColor = UIColor.Dark.base.withAlphaComponent(0.1).cgColor
         $0.layer.borderWidth = 1
-        $0.leftView = UIView(frame: .init(x: 0, y: 0, width: 10, height: 10))
+        $0.leftView = UIView(frame: .init(x: 0, y: 0, width: 12, height: 12))
         $0.leftViewMode = .always
-        $0.rightView = UIView(frame: .init(x: 0, y: 0, width: 10, height: 10))
+        $0.rightView = UIView(frame: .init(x: 0, y: 0, width: 12, height: 12))
         $0.rightViewMode = .always
         $0.autocapitalizationType = .none
         $0.keyboardType = .default

--- a/TripLog/TripLog/Feat-Crois/ModalViewController/View/ModalTextField.swift
+++ b/TripLog/TripLog/Feat-Crois/ModalViewController/View/ModalTextField.swift
@@ -9,7 +9,10 @@ import UIKit
 import SnapKit
 import Then
 
+/// 모달에서 텍스트 입력을 받을 텍스트 필드 공용 컴포넌츠
 final class ModalTextField: UIView {
+    
+    // MARK: - UI Components
     
     private let title = UILabel().then {
         $0.font = UIFont.SCDream(size: .headline, weight: .medium)
@@ -43,6 +46,14 @@ final class ModalTextField: UIView {
         $0.autocapitalizationType = .none
     }
     
+    // MARK: - Initializer
+    
+    /// 텍스트필드 기본 생성자
+    /// - Parameters:
+    ///   - title: 텍스트필드 대제목
+    ///   - subTitle: 텍스트필드 부제목(없을 수 있음)
+    ///   - placeholder: placeholder 텍스트
+    ///   - keyboardType: 키보드 타입 지정
     init(title: String, subTitle: String?, placeholder: String, keyboardType: UIKeyboardType) {
         super.init(frame: .zero)
         
@@ -57,6 +68,7 @@ final class ModalTextField: UIView {
         fatalError("init(coder:) has not been implemented")
     }
     
+    // 앱의 라이트모드/다크모드가 변경 되었을 때 이를 감지하여 CALayer의 컬러를 재정의 해주는 메소드
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
         if traitCollection.hasDifferentColorAppearance(comparedTo: previousTraitCollection) {
@@ -64,11 +76,15 @@ final class ModalTextField: UIView {
         }
     }
     
+    /// 텍스트필드를 세팅하는 메소드
+    /// - Parameter text: 텍스트필드에 넣을 텍스트
     func configTextField(text: String?) {
         textField.text = text
     }
     
 }
+
+// MARK: - UI Setting Method
 
 private extension ModalTextField {
     

--- a/TripLog/TripLog/Feat-Crois/ModalViewController/View/ModalTextField.swift
+++ b/TripLog/TripLog/Feat-Crois/ModalViewController/View/ModalTextField.swift
@@ -41,22 +41,25 @@ final class ModalTextField: UIView {
         $0.rightView = UIView(frame: .init(x: 0, y: 0, width: 12, height: 12))
         $0.rightViewMode = .always
         $0.autocapitalizationType = .none
-        $0.keyboardType = .default
     }
     
-    init(title: String, subTitle: String?, placeholder: String) {
+    init(title: String, subTitle: String?, placeholder: String, keyboardType: UIKeyboardType) {
         super.init(frame: .zero)
         
         self.title.text = title
         self.subTitle.text = subTitle
         self.textField.setPlaceholder(title: placeholder, color: .Light.r400)
         setupUI()
+        self.textField.keyboardType = keyboardType
     }
     
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
     
+    func changeKeyboardType(type: UIKeyboardType) {
+        self.textField.keyboardType = type
+    }
 }
 
 private extension ModalTextField {

--- a/TripLog/TripLog/Feat-Crois/ModalViewController/View/ModalTextField.swift
+++ b/TripLog/TripLog/Feat-Crois/ModalViewController/View/ModalTextField.swift
@@ -78,7 +78,7 @@ final class ModalTextField: UIView {
     
     /// 텍스트필드를 세팅하는 메소드
     /// - Parameter text: 텍스트필드에 넣을 텍스트
-    func configTextField(text: String?) {
+    func configureTextField(text: String?) {
         textField.text = text
     }
     

--- a/TripLog/TripLog/Feat-Crois/ModalViewController/View/ModalTextField.swift
+++ b/TripLog/TripLog/Feat-Crois/ModalViewController/View/ModalTextField.swift
@@ -64,9 +64,10 @@ final class ModalTextField: UIView {
         }
     }
     
-    func changeKeyboardType(type: UIKeyboardType) {
-        self.textField.keyboardType = type
+    func configTextField(text: String?) {
+        textField.text = text
     }
+    
 }
 
 private extension ModalTextField {

--- a/TripLog/TripLog/Feat-Crois/ModalViewController/View/ModalView.swift
+++ b/TripLog/TripLog/Feat-Crois/ModalViewController/View/ModalView.swift
@@ -54,13 +54,24 @@ final class ModalView: UIView {
             self.forthSection = ModalAmoutView()
             self.buttons = ModalButtons(buttonTitle: "생성")
             
-        case .editBudget:
+        case .editBudget(data: let data):
             self.titleLabel.text = state.modalTitle
             self.firstSection = ModalSegmentView()
             self.secondSection = ModalTextField(title: "지출 내용", subTitle: nil, placeholder: "예: 스시 오마카세", keyboardType: .default)
             self.thirdSection = ModalTextField(title: "카테고리", subTitle: nil, placeholder: "예: 식비", keyboardType: .default)
             self.forthSection = ModalAmoutView()
             self.buttons = ModalButtons(buttonTitle: "수정")
+            
+            if let firstSection = self.firstSection as? ModalSegmentView,
+               let secondSection = self.secondSection as? ModalTextField,
+               let thirdSection = self.thirdSection as? ModalTextField,
+               let forthSection = self.forthSection as? ModalAmoutView
+            {
+                firstSection.configSegment(to: data.isCardPayment)
+                secondSection.configTextField(text: data.expenseDetails)
+                thirdSection.configTextField(text: data.category)
+                forthSection.configtAmoutView(amout: data.amount, currency: data.carrency)
+            }
         }
     
         super.init(frame: .zero)

--- a/TripLog/TripLog/Feat-Crois/ModalViewController/View/ModalView.swift
+++ b/TripLog/TripLog/Feat-Crois/ModalViewController/View/ModalView.swift
@@ -11,14 +11,17 @@ import Then
 import RxSwift
 import RxCocoa
 
+/// 모달 뷰 컨트롤러의 뷰로 쓰일 모달 뷰
 final class ModalView: UIView {
+    
+    // MARK: - Rx Properties
     
     fileprivate let cancelButtonTapped = PublishRelay<Void>()
     fileprivate let activeButtonTapped = PublishRelay<Void>()
     
     private let disposeBag = DisposeBag()
     
-    private var state: ModalViewState
+    // MARK: - UI Components
     
     private let titleLabel = UILabel().then {
         $0.font = UIFont.SCDream(size: .subtitle, weight: .bold)
@@ -35,6 +38,16 @@ final class ModalView: UIView {
     private let thirdSection: UIView?
     private let forthSection: UIView?
     
+    // MARK: - Properties
+    
+    private var state: ModalViewState
+    
+    // MARK: - Initializer
+    
+    /// 모달뷰 기본 생성자
+    /// - Parameter state: 모달뷰의 상태를 지정
+    ///
+    /// ``ModalViewState``
     init(state: ModalViewState) {
         self.state = state
         switch state {
@@ -82,11 +95,15 @@ final class ModalView: UIView {
         fatalError("init(coder:) has not been implemented")
     }
     
+    /// 모달뷰의 현재 상태를 반환하는 메소드
+    /// - Returns: 모달뷰의 현재 state
     func checkModalStatus() -> ModalViewState {
         return self.state
     }
     
 }
+
+// MARK: - UI Setting Method
 
 private extension ModalView {
     
@@ -143,6 +160,7 @@ private extension ModalView {
         }
     }
     
+    /// 모달뷰의 버튼을 바인딩 하는 메소드
     func bindButtons() {
         buttons.rx.activeButtondTapped
             .bind(to: activeButtonTapped)
@@ -155,11 +173,15 @@ private extension ModalView {
 
 }
 
+// MARK: - Reactive Extension
+
 extension Reactive where Base: ModalView {
+    /// active 버튼의 tap 이벤트를 방출하는 옵저버블
     var activeButtonTapped: PublishRelay<Void> {
         return base.activeButtonTapped
     }
     
+    /// cancel 버튼의 tap 이벤트를 방출하는 옵저버블
     var cancelButtonTapped: PublishRelay<Void> {
         return base.cancelButtonTapped
     }

--- a/TripLog/TripLog/Feat-Crois/ModalViewController/View/ModalView.swift
+++ b/TripLog/TripLog/Feat-Crois/ModalViewController/View/ModalView.swift
@@ -40,25 +40,25 @@ final class ModalView: UIView {
         switch state {
         case .createNewCashBook:
             self.titleLabel.text = state.modalTitle
-            self.firstSection = ModalTextField(title: "가계부 이름", subTitle: nil, placeholder: "예: 도쿄 여행 2024")
-            self.secondSection = ModalTextField(title: "여행 국가", subTitle: nil, placeholder: "예: 일본")
-            self.thirdSection = ModalTextField(title: "예산 설정", subTitle: "원(한화)", placeholder: "0")
+            self.firstSection = ModalTextField(title: "가계부 이름", subTitle: nil, placeholder: "예: 도쿄 여행 2024", keyboardType: .default)
+            self.secondSection = ModalTextField(title: "여행 국가", subTitle: nil, placeholder: "예: 일본", keyboardType: .default)
+            self.thirdSection = ModalTextField(title: "예산 설정", subTitle: "원(한화)", placeholder: "0", keyboardType: .numberPad)
             self.forthSection = ModalDateView()
             self.buttons = ModalButtons(buttonTitle: "생성")
             
         case .createNewbudget:
             self.titleLabel.text = state.modalTitle
             self.firstSection = ModalSegmentView()
-            self.secondSection = ModalTextField(title: "지출 내용", subTitle: nil, placeholder: "예: 스시 오마카세")
-            self.thirdSection = ModalTextField(title: "카테고리", subTitle: nil, placeholder: "예: 식비")
+            self.secondSection = ModalTextField(title: "지출 내용", subTitle: nil, placeholder: "예: 스시 오마카세", keyboardType: .default)
+            self.thirdSection = ModalTextField(title: "카테고리", subTitle: nil, placeholder: "예: 식비", keyboardType: .default)
             self.forthSection = ModalAmoutView()
             self.buttons = ModalButtons(buttonTitle: "생성")
             
         case .editBudget:
             self.titleLabel.text = state.modalTitle
             self.firstSection = ModalSegmentView()
-            self.secondSection = ModalTextField(title: "지출 내용", subTitle: nil, placeholder: "예: 스시 오마카세")
-            self.thirdSection = ModalTextField(title: "카테고리", subTitle: nil, placeholder: "예: 식비")
+            self.secondSection = ModalTextField(title: "지출 내용", subTitle: nil, placeholder: "예: 스시 오마카세", keyboardType: .default)
+            self.thirdSection = ModalTextField(title: "카테고리", subTitle: nil, placeholder: "예: 식비", keyboardType: .default)
             self.forthSection = ModalAmoutView()
             self.buttons = ModalButtons(buttonTitle: "수정")
         }

--- a/TripLog/TripLog/Feat-Crois/ModalViewController/View/ModalView.swift
+++ b/TripLog/TripLog/Feat-Crois/ModalViewController/View/ModalView.swift
@@ -13,12 +13,12 @@ import RxCocoa
 
 final class ModalView: UIView {
     
-    private(set) var cancelButtonTapped = PublishRelay<Void>()
-    private(set) var activeButtonTapped = PublishRelay<Void>()
+    fileprivate let cancelButtonTapped = PublishRelay<Void>()
+    fileprivate let activeButtonTapped = PublishRelay<Void>()
     
     private let disposeBag = DisposeBag()
     
-    private(set) var state: ModalViewState
+    private var state: ModalViewState
     
     private let titleLabel = UILabel().then {
         $0.font = UIFont.SCDream(size: .subtitle, weight: .bold)
@@ -69,6 +69,10 @@ final class ModalView: UIView {
     
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+    
+    func checkModalStatus() -> ModalViewState {
+        return self.state
     }
     
 }
@@ -129,13 +133,23 @@ private extension ModalView {
     }
     
     func bindButtons() {
-        buttons.createButton.rx.tap
+        buttons.rx.activeButtondTapped
             .bind(to: activeButtonTapped)
             .disposed(by: disposeBag)
         
-        buttons.cancelButton.rx.tap
+        buttons.rx.cancelButtondTapped
             .bind(to: cancelButtonTapped)
             .disposed(by: disposeBag)
     }
 
+}
+
+extension Reactive where Base: ModalView {
+    var activeButtonTapped: PublishRelay<Void> {
+        return base.activeButtonTapped
+    }
+    
+    var cancelButtonTapped: PublishRelay<Void> {
+        return base.cancelButtonTapped
+    }
 }

--- a/TripLog/TripLog/Feat-Crois/ModalViewController/View/ModalView.swift
+++ b/TripLog/TripLog/Feat-Crois/ModalViewController/View/ModalView.swift
@@ -80,10 +80,10 @@ final class ModalView: UIView {
                let thirdSection = self.thirdSection as? ModalTextField,
                let forthSection = self.forthSection as? ModalAmoutView
             {
-                firstSection.configSegment(to: data.isCardPayment)
-                secondSection.configTextField(text: data.expenseDetails)
-                thirdSection.configTextField(text: data.category)
-                forthSection.configtAmoutView(amout: data.amount, currency: data.carrency)
+                firstSection.configureSegment(to: data.isCardPayment)
+                secondSection.configureTextField(text: data.expenseDetails)
+                thirdSection.configureTextField(text: data.category)
+                forthSection.configureAmoutView(amout: data.amount, currency: data.carrency)
             }
         }
     

--- a/TripLog/TripLog/Feat-Crois/ModalViewController/View/ModalView.swift
+++ b/TripLog/TripLog/Feat-Crois/ModalViewController/View/ModalView.swift
@@ -1,0 +1,121 @@
+//
+//  ModalView.swift
+//  TripLog
+//
+//  Created by 장상경 on 1/20/25.
+//
+
+import UIKit
+import SnapKit
+import Then
+
+final class ModalView: UIView {
+    
+    private var state: ModalViewState
+    
+    private let titleLabel = UILabel().then {
+        $0.font = UIFont.SCDream(size: .subtitle, weight: .bold)
+        $0.numberOfLines = 1
+        $0.textColor = UIColor.Dark.base
+        $0.textAlignment = .left
+        $0.backgroundColor = .clear
+    }
+    
+    private let buttons: ModalButtons
+    
+    private let firstSection: UIView?
+    private let secondSection: UIView?
+    private let thirdSection: UIView?
+    private let forthSection: UIView?
+    
+    init(state: ModalViewState) {
+        self.state = state
+        switch state {
+        case .createNewCashBook:
+            self.titleLabel.text = state.modalTitle
+            self.firstSection = ModalTextField(title: "가계부 이름", subTitle: nil, placeholder: "예: 도쿄 여행 2024")
+            self.secondSection = ModalTextField(title: "여행 국가", subTitle: nil, placeholder: "예: 일본")
+            self.thirdSection = ModalTextField(title: "예산 설정", subTitle: "원(한화)", placeholder: "0")
+            self.forthSection = ModalTextField(title: "여행 일정", subTitle: nil, placeholder: "mm/dd/yyyy ~ mm/dd/yyyy")
+            self.buttons = ModalButtons(buttonTitle: "생성")
+            
+        case .createNewbudget:
+            self.titleLabel.text = state.modalTitle
+            self.firstSection = nil
+            self.secondSection = nil
+            self.thirdSection = nil
+            self.forthSection = nil
+            self.buttons = ModalButtons(buttonTitle: "생성")
+            
+        case .editBudget:
+            self.titleLabel.text = state.modalTitle
+            self.firstSection = nil
+            self.secondSection = nil
+            self.thirdSection = nil
+            self.forthSection = nil
+            self.buttons = ModalButtons(buttonTitle: "수정")
+        }
+    
+        super.init(frame: .zero)
+        setupUI()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+private extension ModalView {
+    
+    func setupUI() {
+        configureSelf()
+        setupLayout()
+    }
+    
+    func configureSelf() {
+        self.backgroundColor = .Light.base
+        [titleLabel,
+         firstSection!,
+         secondSection!,
+         thirdSection!,
+         forthSection!,
+         buttons].forEach { self.addSubview($0) }
+    }
+    
+    func setupLayout() {
+        titleLabel.snp.makeConstraints {
+            $0.top.equalToSuperview().offset(16)
+            $0.horizontalEdges.equalToSuperview().inset(24)
+        }
+        
+        firstSection?.snp.makeConstraints {
+            $0.top.equalTo(titleLabel.snp.bottom).offset(16)
+            $0.horizontalEdges.equalToSuperview().inset(24)
+            $0.height.equalTo(66)
+        }
+        
+        secondSection?.snp.makeConstraints {
+            $0.top.equalTo(firstSection!.snp.bottom).offset(16)
+            $0.horizontalEdges.equalToSuperview().inset(24)
+            $0.height.equalTo(66)
+        }
+        
+        thirdSection?.snp.makeConstraints {
+            $0.top.equalTo(secondSection!.snp.bottom).offset(16)
+            $0.horizontalEdges.equalToSuperview().inset(24)
+            $0.height.equalTo(66)
+        }
+        
+        forthSection?.snp.makeConstraints {
+            $0.top.equalTo(thirdSection!.snp.bottom).offset(16)
+            $0.horizontalEdges.equalToSuperview().inset(24)
+            $0.height.equalTo(66)
+        }
+        
+        buttons.snp.makeConstraints {
+            $0.top.equalTo(forthSection!.snp.bottom).offset(16)
+            $0.horizontalEdges.equalToSuperview().inset(24)
+            $0.height.equalTo(44)
+        }
+    }
+}

--- a/TripLog/TripLog/Feat-Crois/ModalViewController/View/ModalView.swift
+++ b/TripLog/TripLog/Feat-Crois/ModalViewController/View/ModalView.swift
@@ -8,10 +8,17 @@
 import UIKit
 import SnapKit
 import Then
+import RxSwift
+import RxCocoa
 
 final class ModalView: UIView {
     
-    private var state: ModalViewState
+    private(set) var cancelButtonTapped = PublishRelay<Void>()
+    private(set) var activeButtonTapped = PublishRelay<Void>()
+    
+    private let disposeBag = DisposeBag()
+    
+    private(set) var state: ModalViewState
     
     private let titleLabel = UILabel().then {
         $0.font = UIFont.SCDream(size: .subtitle, weight: .bold)
@@ -36,23 +43,23 @@ final class ModalView: UIView {
             self.firstSection = ModalTextField(title: "가계부 이름", subTitle: nil, placeholder: "예: 도쿄 여행 2024")
             self.secondSection = ModalTextField(title: "여행 국가", subTitle: nil, placeholder: "예: 일본")
             self.thirdSection = ModalTextField(title: "예산 설정", subTitle: "원(한화)", placeholder: "0")
-            self.forthSection = ModalTextField(title: "여행 일정", subTitle: nil, placeholder: "mm/dd/yyyy ~ mm/dd/yyyy")
+            self.forthSection = ModalDateView()
             self.buttons = ModalButtons(buttonTitle: "생성")
             
         case .createNewbudget:
             self.titleLabel.text = state.modalTitle
-            self.firstSection = nil
-            self.secondSection = nil
-            self.thirdSection = nil
-            self.forthSection = nil
+            self.firstSection = ModalSegmentView()
+            self.secondSection = ModalTextField(title: "지출 내용", subTitle: nil, placeholder: "예: 스시 오마카세")
+            self.thirdSection = ModalTextField(title: "카테고리", subTitle: nil, placeholder: "예: 식비")
+            self.forthSection = ModalAmoutView()
             self.buttons = ModalButtons(buttonTitle: "생성")
             
         case .editBudget:
             self.titleLabel.text = state.modalTitle
-            self.firstSection = nil
-            self.secondSection = nil
-            self.thirdSection = nil
-            self.forthSection = nil
+            self.firstSection = ModalSegmentView()
+            self.secondSection = ModalTextField(title: "지출 내용", subTitle: nil, placeholder: "예: 스시 오마카세")
+            self.thirdSection = ModalTextField(title: "카테고리", subTitle: nil, placeholder: "예: 식비")
+            self.forthSection = ModalAmoutView()
             self.buttons = ModalButtons(buttonTitle: "수정")
         }
     
@@ -63,6 +70,7 @@ final class ModalView: UIView {
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
+    
 }
 
 private extension ModalView {
@@ -70,6 +78,7 @@ private extension ModalView {
     func setupUI() {
         configureSelf()
         setupLayout()
+        bindButtons()
     }
     
     func configureSelf() {
@@ -118,4 +127,15 @@ private extension ModalView {
             $0.height.equalTo(44)
         }
     }
+    
+    func bindButtons() {
+        buttons.createButton.rx.tap
+            .bind(to: activeButtonTapped)
+            .disposed(by: disposeBag)
+        
+        buttons.cancelButton.rx.tap
+            .bind(to: cancelButtonTapped)
+            .disposed(by: disposeBag)
+    }
+
 }

--- a/TripLog/TripLog/Feat-Crois/ModalViewController/View/ModalViewController.swift
+++ b/TripLog/TripLog/Feat-Crois/ModalViewController/View/ModalViewController.swift
@@ -17,7 +17,7 @@ final class ModalViewController: UIViewController {
     
     private let viewModel = ModalViewModel()
     
-    private let modalView: ModalView
+    fileprivate let modalView: ModalView
     
     init(state: ModalViewState) {
         self.modalView = ModalView(state: state)
@@ -88,3 +88,8 @@ private extension ModalViewController {
     }
 }
 
+extension Reactive where Base: ModalViewController {
+    var completedLogic: Observable<Void> {
+        return base.modalView.rx.activeButtonTapped.asObservable()
+    }
+}

--- a/TripLog/TripLog/Feat-Crois/ModalViewController/View/ModalViewController.swift
+++ b/TripLog/TripLog/Feat-Crois/ModalViewController/View/ModalViewController.swift
@@ -54,8 +54,8 @@ private extension ModalViewController {
 
     func bind() {
         let input: ModalViewModel.Input = .init(
-            cancelButtonTapped: self.modalView.cancelButtonTapped,
-            activeButtonTapped: self.modalView.activeButtonTapped
+            cancelButtonTapped: self.modalView.rx.cancelButtonTapped,
+            activeButtonTapped: self.modalView.rx.activeButtonTapped
         )
         
         let output = viewModel.transform(input: input)
@@ -65,7 +65,7 @@ private extension ModalViewController {
             .withUnretained(self)
             .emit { owner, _ in
                 
-                switch owner.modalView.state {
+                switch owner.modalView.checkModalStatus() {
                 case .createNewCashBook: break
                     // 가계부를 코어 데이터에 추가하는 로직
                 case .createNewbudget: break

--- a/TripLog/TripLog/Feat-Crois/ModalViewController/View/ModalViewController.swift
+++ b/TripLog/TripLog/Feat-Crois/ModalViewController/View/ModalViewController.swift
@@ -11,14 +11,27 @@ import Then
 import RxSwift
 import RxCocoa
 
+/// 모달뷰 컨트롤러
 final class ModalViewController: UIViewController {
+    
+    // MARK: - Rx Properties
     
     private let disposeBag = DisposeBag()
     
+    // MARK: - Properties
+    
     private let viewModel = ModalViewModel()
+    
+    // MARK: - UI Components
     
     fileprivate let modalView: ModalView
     
+    // MARK: - Initializer
+    
+    /// 모달 뷰 컨트롤러의 기본 생성자
+    /// - Parameter state: 모달뷰의 state
+    ///
+    /// ``ModalViewState``
     init(state: ModalViewState) {
         self.modalView = ModalView(state: state)
         super.init(nibName: nil, bundle: nil)
@@ -29,6 +42,7 @@ final class ModalViewController: UIViewController {
         fatalError("init(coder:) has not been implemented")
     }
     
+    // MARK: - UIViewController LifeCycle
     override func viewDidLoad() {
         super.viewDidLoad()
         
@@ -36,6 +50,8 @@ final class ModalViewController: UIViewController {
         bind()
     }
     
+    // 뷰 컨트롤러 영역에서 터치 이벤트가 발생하면 editing 모드를 종료
+    // 키보드를 내리기 위한 메소드 재정의
     override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
         super.touchesBegan(touches, with: event)
         
@@ -44,6 +60,8 @@ final class ModalViewController: UIViewController {
     
 }
 
+// MARK: - UI Setting Method
+
 private extension ModalViewController {
     
     func configureSelf() {
@@ -51,8 +69,10 @@ private extension ModalViewController {
         self.sheetPresentationController?.preferredCornerRadius = 12
         self.sheetPresentationController?.detents = [.medium()]
     }
-
+    
+    /// 뷰 모델 바인딩 메소드
     func bind() {
+        
         let input: ModalViewModel.Input = .init(
             cancelButtonTapped: self.modalView.rx.cancelButtonTapped,
             activeButtonTapped: self.modalView.rx.activeButtonTapped
@@ -88,7 +108,10 @@ private extension ModalViewController {
     }
 }
 
+// MARK: - Reactive Extension
+
 extension Reactive where Base: ModalViewController {
+    /// 모달뷰의 active 버튼의 tap 이벤트를 방출하는 옵저버블
     var completedLogic: Observable<Void> {
         return base.modalView.rx.activeButtonTapped.asObservable()
     }

--- a/TripLog/TripLog/Feat-Crois/ModalViewController/View/ModalViewController.swift
+++ b/TripLog/TripLog/Feat-Crois/ModalViewController/View/ModalViewController.swift
@@ -112,7 +112,7 @@ private extension ModalViewController {
 
 extension Reactive where Base: ModalViewController {
     /// 모달뷰의 active 버튼의 tap 이벤트를 방출하는 옵저버블
-    var completedLogic: Observable<Void> {
-        return base.modalView.rx.activeButtonTapped.asObservable()
+    var completedLogic: PublishRelay<Void> {
+        return base.modalView.rx.activeButtonTapped
     }
 }

--- a/TripLog/TripLog/Feat-Crois/ModalViewController/View/ModalViewController.swift
+++ b/TripLog/TripLog/Feat-Crois/ModalViewController/View/ModalViewController.swift
@@ -1,0 +1,48 @@
+//
+//  ModalViewController.swift
+//  TripLog
+//
+//  Created by 장상경 on 1/20/25.
+//
+
+import UIKit
+import SnapKit
+import Then
+
+final class ModalViewController: UIViewController {
+    
+    private let modalView: ModalView
+    
+    init(state: ModalViewState) {
+        self.modalView = ModalView(state: state)
+        super.init(nibName: nil, bundle: nil)
+        configureSelf()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        view = self.modalView
+    }
+    
+    override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
+        super.touchesBegan(touches, with: event)
+        
+        self.view.endEditing(true)
+    }
+}
+
+private extension ModalViewController {
+    
+    func configureSelf() {
+        self.modalPresentationStyle = .formSheet
+        self.sheetPresentationController?.preferredCornerRadius = 12
+        self.sheetPresentationController?.detents = [.medium()]
+    }
+}
+
+

--- a/TripLog/TripLog/Feat-Crois/ModalViewController/ViewModel/ModalViewModel.swift
+++ b/TripLog/TripLog/Feat-Crois/ModalViewController/ViewModel/ModalViewModel.swift
@@ -1,0 +1,53 @@
+//
+//  ModalViewModel.swift
+//  TripLog
+//
+//  Created by 장상경 on 1/20/25.
+//
+
+import UIKit
+import RxSwift
+import RxCocoa
+
+final class ModalViewModel: ViewModelType {
+    
+    struct Input {
+        let cancelButtonTapped: PublishRelay<Void>
+        let activeButtonTapped: PublishRelay<Void>
+    }
+    
+    struct Output {
+        let modalDismiss: PublishRelay<Void>
+        let active: PublishRelay<Void>
+    }
+    
+    let disposeBag = DisposeBag()
+    
+    private let modalDismiss = PublishRelay<Void>()
+    private let active = PublishRelay<Void>()
+    
+    func transform(input: Input) -> Output {
+        input.activeButtonTapped
+            .asSignal(onErrorSignalWith: .empty())
+            .withUnretained(self)
+            .emit { owner, _ in
+                
+                owner.active.accept(())
+                
+            }.disposed(by: disposeBag)
+        
+        input.cancelButtonTapped
+            .asSignal(onErrorSignalWith: .empty())
+            .withUnretained(self)
+            .emit { owner, _ in
+                
+                owner.modalDismiss.accept(())
+                
+            }.disposed(by: disposeBag)
+        
+        return Output(
+            modalDismiss: self.modalDismiss,
+            active: self.active
+        )
+    }
+}

--- a/TripLog/TripLog/Feat-Crois/ModalViewController/ViewModel/ModalViewModel.swift
+++ b/TripLog/TripLog/Feat-Crois/ModalViewController/ViewModel/ModalViewModel.swift
@@ -9,6 +9,7 @@ import UIKit
 import RxSwift
 import RxCocoa
 
+/// 모달 뷰 컨트롤러의 비즈니스 로직 담당 뷰 모델
 final class ModalViewModel: ViewModelType {
     
     struct Input {
@@ -26,6 +27,14 @@ final class ModalViewModel: ViewModelType {
     private let modalDismiss = PublishRelay<Void>()
     private let active = PublishRelay<Void>()
     
+    /// input을 output으로 변환해주는 메소드
+    /// - Parameter input:
+    /// **cancelButtonTapped**: 취소 버튼의 탭 이벤트를 방출하는 옵저버블
+    /// **activeButtonTapped**: active 버튼의 탭 이벤트를 방출하는 옵저버블
+    ///
+    /// - Returns:
+    /// **modalDismiss**: 취소 버튼이 눌리면 모달을 닫도록 이벤트를 방출하는 옵저버블
+    /// **active**: active 버튼을 통해 특정 로직을 실행하도록 이벤트를 방출하는 옵저버블
     func transform(input: Input) -> Output {
         input.activeButtonTapped
             .asSignal(onErrorSignalWith: .empty())

--- a/TripLog/TripLog/Source/Extension/UIFont+Extension.swift
+++ b/TripLog/TripLog/Source/Extension/UIFont+Extension.swift
@@ -19,32 +19,41 @@ extension UIFont {
     }
     
     static func SCDream(size fontSize: FontSize, weight: UIFont.Weight) -> UIFont {
-        let familyName = "SCDream"
+        let familyName = "S-CoreDream-"
         
         var weightString: String
         switch weight {
         case .black:
-            weightString = "9"
+            weightString = "9Black"
         case .bold:
-            weightString = "7"
+            weightString = "7ExtraBold"
         case .heavy:
-            weightString = "8"
+            weightString = "8Heavy"
         case .ultraLight:
-            weightString = "2"
+            weightString = "2ExtraLight"
         case .light:
-            weightString = "3"
+            weightString = "3Lihgt"
         case .medium:
-            weightString = "5"
+            weightString = "5Medium"
         case .regular:
-            weightString = "4"
+            weightString = "4Regular"
         case .semibold:
-            weightString = "6"
+            weightString = "6Bold"
         case .thin:
-            weightString = "1"
+            weightString = "1Thin"
         default:
-            weightString = "4"
+            weightString = "4Regular"
         }
         
         return UIFont(name: "\(familyName)\(weightString)", size: fontSize.rawValue) ?? .systemFont(ofSize: fontSize.rawValue, weight: weight)
+    }
+    
+    static func printAll() {
+        familyNames.sorted().forEach { familyName in
+            print("*** \(familyName) ***")
+            fontNames(forFamilyName: familyName).sorted().forEach { fontName in
+                print("\(fontName)")
+            }
+        }
     }
 }

--- a/TripLog/TripLog/Source/Extension/UITextField+Extension.swift
+++ b/TripLog/TripLog/Source/Extension/UITextField+Extension.swift
@@ -9,6 +9,10 @@ import Foundation
 import UIKit
 
 extension UITextField {
+    /// 텍스트필드의 플레이스홀더를 세팅하는 메소드
+    /// - Parameters:
+    ///   - title: 플레이스홀더의 텍스트
+    ///   - color: 플레이스홀더의 컬러
     func setPlaceholder(title: String, color: UIColor) {
         let title = title
         self.attributedPlaceholder = NSAttributedString(

--- a/TripLog/TripLog/Source/Extension/UITextField+Extension.swift
+++ b/TripLog/TripLog/Source/Extension/UITextField+Extension.swift
@@ -5,7 +5,6 @@
 //  Created by 장상경 on 1/20/25.
 //
 
-import Foundation
 import UIKit
 
 extension UITextField {

--- a/TripLog/TripLog/Source/Extension/UITextField+Extension.swift
+++ b/TripLog/TripLog/Source/Extension/UITextField+Extension.swift
@@ -1,0 +1,19 @@
+//
+//  UITextField+Extension.swift
+//  TripLog
+//
+//  Created by 장상경 on 1/20/25.
+//
+
+import Foundation
+import UIKit
+
+extension UITextField {
+    func setPlaceholder(title: String, color: UIColor) {
+        let title = title
+        self.attributedPlaceholder = NSAttributedString(
+            string: title,
+            attributes: [NSAttributedString.Key.foregroundColor: color]
+        )
+    }
+}

--- a/TripLog/TripLogTests/ModalViewControllerTests.swift
+++ b/TripLog/TripLogTests/ModalViewControllerTests.swift
@@ -28,6 +28,7 @@ final class ModalViewControllerTests: XCTestCase {
         
     }
     
+    // 모달뷰 active 버튼 액션 테스트
     func testModalViewControllerCompletedAction() throws {
         // given
         let input = sut.rx.completedLogic

--- a/TripLog/TripLogTests/ModalViewControllerTests.swift
+++ b/TripLog/TripLogTests/ModalViewControllerTests.swift
@@ -1,0 +1,50 @@
+//
+//  ModalViewControllerTests.swift
+//  TripLogTests
+//
+//  Created by 장상경 on 1/22/25.
+//
+
+import XCTest
+import RxSwift
+import RxCocoa
+@testable import TripLog
+
+final class ModalViewControllerTests: XCTestCase {
+    
+    private var sut: ModalViewController!
+    
+    override func setUpWithError() throws {
+        
+        sut = ModalViewController(state: .createNewCashBook)
+        try super.setUpWithError()
+        
+    }
+    
+    override func tearDownWithError() throws {
+        
+        sut = nil
+        try super.tearDownWithError()
+        
+    }
+    
+    func testModalViewControllerCompletedAction() throws {
+        // given
+        let input = sut.rx.completedLogic
+        let disposBag = DisposeBag()
+        var result: String = ""
+        
+        // when
+        input
+            .subscribe(onNext: {
+                result = "Completed"
+            }, onError: { error in
+                result = "\(error)"
+            }).disposed(by: disposBag)
+        
+        input.accept(())
+        
+        // then
+        XCTAssertEqual(result, "Completed", "🚨 ModalViewControllerCompletedAction is wrong")
+    }
+}

--- a/TripLog/TripLogTests/ModalViewTests.swift
+++ b/TripLog/TripLogTests/ModalViewTests.swift
@@ -1,0 +1,80 @@
+//
+//  ModalViewControllerTests.swift
+//  TripLogTests
+//
+//  Created by 장상경 on 1/22/25.
+//
+
+import XCTest
+import RxSwift
+import RxCocoa
+@testable import TripLog
+
+final class ModalViewTests: XCTestCase {
+    
+    private var sut: ModalView!
+    
+    override func setUpWithError() throws {
+
+        sut = ModalView(state: .createNewCashBook)
+        try super.setUpWithError()
+        
+    }
+
+    override func tearDownWithError() throws {
+
+        sut = nil
+        try super.tearDownWithError()
+        
+    }
+    
+    func testCheckModalViewStatus() throws {
+        // given (modalView State = .createNewCashBook)
+        
+        // when
+        let result = sut.checkModalStatus().modalTitle
+        
+        // then
+        XCTAssertEqual(result, "새 가계부 만들기", "🚨 ModalView's Status is not createNewCashBook")
+        XCTAssertEqual(result, "새 지출내역 추가하기", "🚨 ModalView's Status is not createNewbudget")
+        XCTAssertEqual(result, "지출내역 수정하기", "🚨 ModalView's Status is not editBudget")
+    }
+    
+    func testModalViewActiveButtonTapped() throws {
+        // given
+        let input = sut.rx.activeButtonTapped
+        let disposeBag = DisposeBag()
+        var result: String = ""
+        
+        // when
+        input.subscribe(onNext: {
+            result = "activeButtonTapped"
+        }).disposed(by: disposeBag)
+        
+        input.accept(())
+        
+        // then
+        XCTAssertEqual(result, "activeButtonTapped", "🚨 activeButtonTapped function is wrong")
+    }
+    
+    func testModalViewCancelButtonTapped() throws {
+        // given
+        let input = sut.rx.cancelButtonTapped
+        let disposeBag = DisposeBag()
+        var result: String = ""
+        
+        // when
+        input
+            .subscribe(onNext: {
+                result = "cancelButtonTapped"
+            }, onError: { error in
+                result = "\(error)"
+            }).disposed(by: disposeBag)
+        
+        input.accept(())
+        
+        // then
+        XCTAssertEqual(result, "cancelButtonTapped", "🚨 cancelButtonTapped function is wrong")
+    }
+    
+}

--- a/TripLog/TripLogTests/ModalViewTests.swift
+++ b/TripLog/TripLogTests/ModalViewTests.swift
@@ -28,6 +28,7 @@ final class ModalViewTests: XCTestCase {
         
     }
     
+    // 모달뷰의 현태 status를 가져오는 메소드 테스트
     func testCheckModalViewStatus() throws {
         // given (modalView State = .createNewCashBook)
         
@@ -40,6 +41,7 @@ final class ModalViewTests: XCTestCase {
         XCTAssertEqual(result, "지출내역 수정하기", "🚨 ModalView's Status is not editBudget")
     }
     
+    // 모달뷰의 active 버튼 이벤트 방출 테스트
     func testModalViewActiveButtonTapped() throws {
         // given
         let input = sut.rx.activeButtonTapped
@@ -57,6 +59,7 @@ final class ModalViewTests: XCTestCase {
         XCTAssertEqual(result, "activeButtonTapped", "🚨 activeButtonTapped function is wrong")
     }
     
+    // 모달뷰의 취소 버튼 이벤트 방출 테스트
     func testModalViewCancelButtonTapped() throws {
         // given
         let input = sut.rx.cancelButtonTapped


### PR DESCRIPTION
이슈 번호: close #2

## 요약
- 모달VC의 UI 구현 완료
- 모달VC를 메소드를 통해 present 하는 로직 구현 완료
- 가계부 추가 UI 구현
- 지출 내역 추가 UI 구현
- 지출 내역 수정 로직 구현(임시)

## 작업 상세 내용

가계부를 추가하고, 지출 내역을 추가/수정 할 수 있는 모달VC의 구현을 완료했습니다.
`ModalViewManager`라는 `enum` 타입의 네임스페이스를 만들어 `showModal` 메소드를 통해 모달VC를 원하는 뷰 컨트롤러에 present 할 수 있습니다.
```swift
// 사용 예시
func showModal() {
    ModalViewManager.showModal(on: self, state: .createNewCashBook)
        .subscribe(onNext: { _ in
            print("Completed")
        }).disposed(by: disposeBag)
}
```
위의 코드를 보시면 아시겠지만, `showModal`은 return 타입이 `Observable<Void>` 타입입니다.
이를 활용하여 모달VC에서 '생성', '수정' 등의 active 버튼을 누른 뒤에 뷰 컨트롤러에서 어떤 동작을 할 것인지 rx 데이터 바인딩을 통해 구현할 수 있습니다.

예를 들어 가계부를 새로 추가한다면, 새로 추가된 가계부를 곧바로 코어데이터에서 로드하는 로직을 구현할 수 있습니다.

## 리뷰어 공유사항

지출 내역 수정 로직이 제대로 작동하는지 확인을 위해 테스트 더미를 만들어 체크했습니다.
추후 `TestModalViewData`를 제거하고 코어 데이터의 엔티티와 관련된 데이터 타입으로 수정 예정입니다.
```swift
// 테스트 더미 파일
struct TestModalViewData {
    let isCardPayment: Bool
    let expenseDetails: String?
    let category: String?
    let carrency: Currency
    let amount: Int?
}
```

현재 지출 내역을 추가/수정 하는 UI에서 통화를 선택하는 로직과 선택된 통화를 불러오는 로직을 임의로 배정했습니다.
추후 코어 데이터 엔티티 작업이 완료되면 로직의 전체적인 수정이 있을 예정이니 코드 리뷰시 참고 바랍니다.

추가로, 현재는 모달VC에서 입력란이 모두 공란이더라도 데이터를 저장할 수 있도록 로직을 구현했는데, `Alert`을 통해 비어있으면 안된다는 알림을 주는 것이 좋지 않을까 생각합니다. 여러분의 의견을 구하고 싶습니다.

만약 `Alert`을 통해 구현하는게 좋다고 판단될 경우, 다양한 곳에서 `Alert`을 사용할 수 있도록 `AlertManager` 등의 파일을 만들어 재사용성을 높인 `Alert`을 만드는 것을 구상하고 있습니다.

## 스크린샷(선택)

| 가계부 추가 | 지출 내역 추가 | 지출 내역 수정 |
| :-: | :-: | :-: |
| ![1](https://github.com/user-attachments/assets/9611da02-7265-4534-b6c4-30e8b385468e) | ![2](https://github.com/user-attachments/assets/2966033f-7b8b-4254-9f1e-dddf76a2fccb) | ![3](https://github.com/user-attachments/assets/233b22cc-4f4d-46d1-b931-c76c30bb28bc) |


