### PR TITLE
[Feat] Alert 매니저 구현

### DIFF
--- a/TripLog/TripLog/Feat-Crois/AlertManager/AlertManager.swift
+++ b/TripLog/TripLog/Feat-Crois/AlertManager/AlertManager.swift
@@ -5,4 +5,73 @@
 //  Created by 장상경 on 1/23/25.
 //
 
-import Foundation
+import UIKit
+
+struct AlertManager {
+    let title: String
+    let message: String
+    let cancelTitle: String
+    let activeTitle: String?
+    let destructiveTitle: String?
+    let completion: (() -> Void)?
+    
+    init(title: String,
+         message: String,
+         cancelTitle: String,
+         activeTitle: String?,
+         completion: (() -> Void)?
+    ) {
+        self.title = title
+        self.message = message
+        self.cancelTitle = cancelTitle
+        self.activeTitle = activeTitle
+        self.completion = completion
+        self.destructiveTitle = nil
+    }
+    
+    init(title: String,
+         message: String,
+         cancelTitle: String,
+         destructiveTitle: String?,
+         completion: (() -> Void)?
+    ) {
+        self.title = title
+        self.message = message
+        self.cancelTitle = cancelTitle
+        self.destructiveTitle = destructiveTitle
+        self.completion = completion
+        self.activeTitle = nil
+    }
+    
+    init(title: String,
+         message: String,
+         cancelTitle: String
+    ) {
+        self.title = title
+        self.message = message
+        self.cancelTitle = cancelTitle
+        self.activeTitle = nil
+        self.destructiveTitle = nil
+        self.completion = nil
+    }
+    
+    func showAlert(on view: UIViewController, _ style: UIAlertController.Style) {
+        let alert = UIAlertController(title: self.title, message: self.message, preferredStyle: style)
+        alert.addAction(UIAlertAction(title: self.cancelTitle, style: .cancel))
+        
+        if let activeTitle {
+            alert.addAction(UIAlertAction(title: activeTitle, style: .default) { [weak view] _ in
+                completion?()
+            })
+        } else if let destructiveTitle {
+            alert.addAction(UIAlertAction(title: destructiveTitle, style: .destructive) { [weak view] _ in
+                completion?()
+            })
+        }
+        
+        view.present(alert, animated: true)
+    }
+    
+}
+
+

--- a/TripLog/TripLog/Feat-Crois/AlertManager/AlertManager.swift
+++ b/TripLog/TripLog/Feat-Crois/AlertManager/AlertManager.swift
@@ -7,6 +7,17 @@
 
 import UIKit
 
+/**
+ 프로젝트 전역에서 사용할 Alert 객체
+ 
+ - **Example**:
+ ```swift
+ // 기본적인 Alert 사용 방법
+ let alert = AlertManager(title: "알림", message: "저장하시겠습니까?", cancelTitle: "취소")
+ 
+ alert.showAlert(on: self, .alert)
+ ```
+ */
 struct AlertManager {
     let title: String
     let message: String
@@ -15,6 +26,24 @@ struct AlertManager {
     let destructiveTitle: String?
     let completion: (() -> Void)?
     
+    // 가장 기본적인 형태의 Alert
+    // cancel 버튼만 보유
+    // handler 없음
+    init(title: String,
+         message: String,
+         cancelTitle: String
+    ) {
+        self.title = title
+        self.message = message
+        self.cancelTitle = cancelTitle
+        self.activeTitle = nil
+        self.destructiveTitle = nil
+        self.completion = nil
+    }
+    
+    // 2개의 선택지를 제공하는 Alert
+    // defaults 형태의 버튼 제공
+    // handler 있음
     init(title: String,
          message: String,
          cancelTitle: String,
@@ -29,6 +58,9 @@ struct AlertManager {
         self.destructiveTitle = nil
     }
     
+    // 2개의 선택지를 제공하는 Alert
+    // destructive 형태의 버튼 제공
+    // handler 있음
     init(title: String,
          message: String,
          cancelTitle: String,
@@ -43,18 +75,10 @@ struct AlertManager {
         self.activeTitle = nil
     }
     
-    init(title: String,
-         message: String,
-         cancelTitle: String
-    ) {
-        self.title = title
-        self.message = message
-        self.cancelTitle = cancelTitle
-        self.activeTitle = nil
-        self.destructiveTitle = nil
-        self.completion = nil
-    }
-    
+    /// Alert 을 뷰 컨트롤러에 present 하는 메소드
+    /// - Parameters:
+    ///   - view: Alert을 present 할 뷰 컨트롤러
+    ///   - style: AlertViewController Style
     func showAlert(on view: UIViewController, _ style: UIAlertController.Style) {
         let alert = UIAlertController(title: self.title, message: self.message, preferredStyle: style)
         alert.addAction(UIAlertAction(title: self.cancelTitle, style: .cancel))

--- a/TripLog/TripLog/Feat-Crois/AlertManager/AlertManager.swift
+++ b/TripLog/TripLog/Feat-Crois/AlertManager/AlertManager.swift
@@ -1,0 +1,8 @@
+//
+//  AlertManager.swift
+//  TripLog
+//
+//  Created by 장상경 on 1/23/25.
+//
+
+import Foundation


### PR DESCRIPTION
이슈 번호: close #13 

## 요약
- 프로젝트 전역에서 사용할 수 있는 `AlertManager`를 구현
- 재사용성을 고려하여 `struct`로 구현
- `Alert`의 커스텀을 가능하도록 하기 위해 UIAlertController를 상속하지 않고 구현

## 작업 상세 내용
`Alert`을 전역에서 사용할 수 있도록 구현했습니다.
`init`을 통해 `Alert`에 필요한 내용을 작성하고, `showAlert(on:, _:)`을 통해 `Alert`을 Present 할 수 있습니다.
```swift
// 사용 예시
let alert = AlertManager(title: "알림", message: "저장하시겠습니까?", cancelTitle: "취소")
 
alert.showAlert(on: self, .alert)
```

## 리뷰어 공유사항
`AlertManager`는 3가지의 `init`을 제공합니다.
상황에 맞춰 사용해 주시면 됩니다.

## 스크린샷(선택)

| cancel only | default | destructive |
| :-: | :-: | :-: |
| ![3](https://github.com/user-attachments/assets/8c372c63-8bf5-4913-a3ff-1942cff49af4) | ![1](https://github.com/user-attachments/assets/baa8e6be-85e7-4ecf-9198-ecfbc0abe3b4) | ![2](https://github.com/user-attachments/assets/3c702296-acf5-4f5c-a9fb-9408251314a6) |