### PR TITLE
[Feat] 가계부 리스트 화면 구현

### DIFF
--- a/TripLog/TripLog/Feat-Jeff/CashBookList/Model/CashBookListModel.swift
+++ b/TripLog/TripLog/Feat-Jeff/CashBookList/Model/CashBookListModel.swift
@@ -7,34 +7,35 @@
 import Foundation
 import RxDataSources
 
-/// 가계부 리스트의 데이터 여부 case
-enum ListStateSection {
-    case emptyState
-    case existState
-}
-
 /// Core Data의 엔티티를 기반으로 하는 가계부 데이터 모델
 /// RxDataSource와 View에서 사용하기 위해 변환된 데이터 모델
-struct ListCellData {
-    var tripName: String
-    var note: String
-    var buget: Double
-    var departure: String // 추후 date
-    var homecoming: String // 추후 date
+struct ListCellData: Identifiable {
+    let id: UUID
+    let tripName: String
+    let note: String
+    let buget: Double
+    let departure: String
+    let homecoming: String
+    
+    init(tripName: String, note: String, buget: Double, departure: String, homecoming: String) {
+        self.id = UUID()
+        self.tripName = tripName
+        self.note = note
+        self.buget = buget
+        self.departure = departure
+        self.homecoming = homecoming
+    }
 }
 
 /// RxDataSource에서 사용되는 모델
-/// state : section
-/// items : item
 struct SectionOfListCellData {
-    let state: ListStateSection
-    var items: [Item]
+    var items: [ListCellData]
 }
 
 extension SectionOfListCellData: SectionModelType {
     typealias Item = ListCellData
     
-    init(original: SectionOfListCellData, items: [Item]) {
+    init(original: SectionOfListCellData, items: [ListCellData]) {
         self = original
         self.items = items
     }

--- a/TripLog/TripLog/Feat-Jeff/CashBookList/Model/CashBookListModel.swift
+++ b/TripLog/TripLog/Feat-Jeff/CashBookList/Model/CashBookListModel.swift
@@ -8,7 +8,8 @@ import Foundation
 import RxDataSources
 
 /// Core Data의 엔티티를 기반으로 하는 가계부 데이터 모델
-/// RxDataSource와 View에서 사용하기 위해 변환된 데이터 모델
+/// - RxDataSource와 View에서 사용하기 위해 변환된 데이터 모델
+/// - 추후 identity의 사용 여부 고려(코어데이터의 NSManagedObjectID)
 struct ListCellData: Equatable, IdentifiableType {
     var identity: UUID
     let tripName: String
@@ -29,8 +30,9 @@ struct ListCellData: Equatable, IdentifiableType {
 
 /// RxDataSource에서 사용되는 모델
 struct SectionOfListCellData {
-    var items: [ListCellData]
+    // 섹션이 필요는 없지만 RxDataSource에서 필요로 할 수 있다
     var identity: UUID
+    var items: [ListCellData]
 }
 
 extension SectionOfListCellData: AnimatableSectionModelType {

--- a/TripLog/TripLog/Feat-Jeff/CashBookList/Model/CashBookListModel.swift
+++ b/TripLog/TripLog/Feat-Jeff/CashBookList/Model/CashBookListModel.swift
@@ -1,0 +1,44 @@
+//
+//  CashBookListModel.swift
+//  TripLog
+//
+//  Created by jae hoon lee on 1/21/25.
+//
+import Foundation
+import RxDataSources
+
+/// 가계부 리스트의 데이터 여부 case
+enum ListStateSection {
+    case emptyState
+    case existState
+}
+
+/// Core Data의 엔티티를 기반으로 하는 가계부 데이터 모델
+/// RxDataSource와 View에서 사용하기 위해 변환된 데이터 모델
+struct ListCellData {
+    var tripName: String
+    var note: String
+    var buget: Double
+    var departure: String // 추후 date
+    var homecoming: String // 추후 date
+}
+
+/// RxDataSource에서 사용되는 모델
+/// state : section
+/// items : item
+struct SectionOfListCellData {
+    let state: ListStateSection
+    var items: [Item]
+}
+
+extension SectionOfListCellData: SectionModelType {
+    typealias Item = ListCellData
+    
+    init(original: SectionOfListCellData, items: [Item]) {
+        self = original
+        self.items = items
+    }
+}
+
+
+

--- a/TripLog/TripLog/Feat-Jeff/CashBookList/Model/CashBookListModel.swift
+++ b/TripLog/TripLog/Feat-Jeff/CashBookList/Model/CashBookListModel.swift
@@ -10,22 +10,18 @@ import RxDataSources
 /// Core Data의 엔티티를 기반으로 하는 가계부 데이터 모델
 /// - RxDataSource와 View에서 사용하기 위해 변환된 데이터 모델
 /// - 추후 identity의 사용 여부 고려(코어데이터의 NSManagedObjectID)
-struct ListCellData: Equatable, IdentifiableType {
-    var identity: UUID
+struct ListCellData: Hashable, IdentifiableType {
+    /* 추후 코어데이터로 변경시 적용 예정
+    typealias Identity = UUID
+    var identity: Identity { UUID() }
+     */
+    
+    var identity = UUID()
     let tripName: String
     let note: String
     let buget: Double
     let departure: String
     let homecoming: String
-    
-    init(tripName: String, note: String, buget: Double, departure: String, homecoming: String) {
-        self.identity = UUID()
-        self.tripName = tripName
-        self.note = note
-        self.buget = buget
-        self.departure = departure
-        self.homecoming = homecoming
-    }
 }
 
 /// RxDataSource에서 사용되는 모델

--- a/TripLog/TripLog/Feat-Jeff/CashBookList/Model/CashBookListModel.swift
+++ b/TripLog/TripLog/Feat-Jeff/CashBookList/Model/CashBookListModel.swift
@@ -9,8 +9,8 @@ import RxDataSources
 
 /// Core Data의 엔티티를 기반으로 하는 가계부 데이터 모델
 /// RxDataSource와 View에서 사용하기 위해 변환된 데이터 모델
-struct ListCellData: Identifiable {
-    let id: UUID
+struct ListCellData: Equatable, IdentifiableType {
+    var identity: UUID
     let tripName: String
     let note: String
     let buget: Double
@@ -18,7 +18,7 @@ struct ListCellData: Identifiable {
     let homecoming: String
     
     init(tripName: String, note: String, buget: Double, departure: String, homecoming: String) {
-        self.id = UUID()
+        self.identity = UUID()
         self.tripName = tripName
         self.note = note
         self.buget = buget
@@ -30,9 +30,10 @@ struct ListCellData: Identifiable {
 /// RxDataSource에서 사용되는 모델
 struct SectionOfListCellData {
     var items: [ListCellData]
+    var identity: UUID
 }
 
-extension SectionOfListCellData: SectionModelType {
+extension SectionOfListCellData: AnimatableSectionModelType {
     typealias Item = ListCellData
     
     init(original: SectionOfListCellData, items: [ListCellData]) {
@@ -40,6 +41,3 @@ extension SectionOfListCellData: SectionModelType {
         self.items = items
     }
 }
-
-
-

--- a/TripLog/TripLog/Feat-Jeff/CashBookList/Service/PriceFormatModel.swift
+++ b/TripLog/TripLog/Feat-Jeff/CashBookList/Service/PriceFormatModel.swift
@@ -16,7 +16,9 @@ struct PriceFormatModel {
         return formatter
     }()
     
-    /// 세자릿 수 표현 (ex: 1,000,000 원)
+    /// 세자릿 수 표현
+    /// parmeter(Int) : 1000000
+    /// return(String) : 1,000,000 원
     static func wonFormat(_ number: Int) -> String {
         let result = formatter.string(from: NSNumber(value: number)) ?? "0"
         return result + " 원"

--- a/TripLog/TripLog/Feat-Jeff/CashBookList/Service/PriceFormatModel.swift
+++ b/TripLog/TripLog/Feat-Jeff/CashBookList/Service/PriceFormatModel.swift
@@ -1,0 +1,23 @@
+//
+//  PriceFormatModel.swift
+//  TripLog
+//
+//  Created by jae hoon lee on 1/20/25.
+//
+import Foundation
+
+struct PriceFormatModel {
+
+    // 1000 단위 구분
+    static let formatter: NumberFormatter = {
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .decimal
+        formatter.groupingSeparator = ","
+        return formatter
+    }()
+
+    static func wonFormat(_ number: Int) -> String {
+        let result = formatter.string(from: NSNumber(value: number)) ?? "0"
+        return result + " 원"
+    }
+}

--- a/TripLog/TripLog/Feat-Jeff/CashBookList/Service/PriceFormatModel.swift
+++ b/TripLog/TripLog/Feat-Jeff/CashBookList/Service/PriceFormatModel.swift
@@ -6,7 +6,7 @@
 //
 import Foundation
 
-struct PriceFormatModel {
+extension NumberFormatter {
     
     /// 1000 단위 구분
     static let formatter: NumberFormatter = {
@@ -23,4 +23,6 @@ struct PriceFormatModel {
         let result = formatter.string(from: NSNumber(value: number)) ?? "0"
         return result + " 원"
     }
+    
 }
+

--- a/TripLog/TripLog/Feat-Jeff/CashBookList/Service/PriceFormatModel.swift
+++ b/TripLog/TripLog/Feat-Jeff/CashBookList/Service/PriceFormatModel.swift
@@ -7,15 +7,16 @@
 import Foundation
 
 struct PriceFormatModel {
-
-    // 1000 단위 구분
+    
+    /// 1000 단위 구분
     static let formatter: NumberFormatter = {
         let formatter = NumberFormatter()
         formatter.numberStyle = .decimal
         formatter.groupingSeparator = ","
         return formatter
     }()
-
+    
+    /// 세자릿 수 표현 (ex: 1,000,000 원)
     static func wonFormat(_ number: Int) -> String {
         let result = formatter.string(from: NSNumber(value: number)) ?? "0"
         return result + " 원"

--- a/TripLog/TripLog/Feat-Jeff/CashBookList/View/AddCellView.swift
+++ b/TripLog/TripLog/Feat-Jeff/CashBookList/View/AddCellView.swift
@@ -37,10 +37,10 @@ final class AddCellView: UIView {
 
 //MARK: - Method
 
-extension AddCellView {
+private extension AddCellView {
     
     /// setup UI
-    private func setupUI() {
+    func setupUI() {
         backgroundColor = .white
         
         [
@@ -50,7 +50,7 @@ extension AddCellView {
     }
     
     /// setup Constraints
-    private func setupConstraints() {
+    func setupConstraints() {
         addNameLabel.snp.makeConstraints {
             $0.top.equalToSuperview().offset(20)
             $0.horizontalEdges.equalToSuperview().inset(24)
@@ -64,7 +64,7 @@ extension AddCellView {
     }
     
     /// 그림자 추가(추후 변경 예정)
-    private func setupShadow() {
+    func setupShadow() {
         layer.borderWidth = 0.2
         layer.borderColor = UIColor.lightGray.cgColor
         

--- a/TripLog/TripLog/Feat-Jeff/CashBookList/View/AddCellView.swift
+++ b/TripLog/TripLog/Feat-Jeff/CashBookList/View/AddCellView.swift
@@ -7,13 +7,8 @@
 import UIKit
 import SnapKit
 import Then
-import RxCocoa
-import RxSwift
 
 final class AddCellView: UIView {
-    
-    var disposeBag = DisposeBag()
-    let addButtonTapped = PublishRelay<Void>()
     
     private let addNameLabel = UILabel().then {
         $0.text = "여행 추가하기"
@@ -30,6 +25,7 @@ final class AddCellView: UIView {
         super.init(frame: frame)
         
         setupUI()
+        setupConstraints()
         setupShadow()
     }
     
@@ -37,7 +33,13 @@ final class AddCellView: UIView {
         fatalError("init(coder:) has not been implemented")
     }
     
-    /// setupUI
+}
+
+//MARK: - Method
+
+extension AddCellView {
+    
+    /// setup UI
     private func setupUI() {
         backgroundColor = .white
         
@@ -45,7 +47,10 @@ final class AddCellView: UIView {
             addButton,
             addNameLabel
         ].forEach { addSubview($0) }
-        
+    }
+    
+    /// setup Constraints
+    private func setupConstraints() {
         addNameLabel.snp.makeConstraints {
             $0.top.equalToSuperview().offset(20)
             $0.horizontalEdges.equalToSuperview().inset(24)
@@ -58,7 +63,7 @@ final class AddCellView: UIView {
         }
     }
     
-    /// 셀에 그림자 추가
+    /// 그림자 추가(추후 변경 예정)
     private func setupShadow() {
         layer.borderWidth = 0.2
         layer.borderColor = UIColor.lightGray.cgColor
@@ -70,4 +75,5 @@ final class AddCellView: UIView {
         layer.shadowRadius = 4
         layer.masksToBounds = false
     }
+    
 }

--- a/TripLog/TripLog/Feat-Jeff/CashBookList/View/AddCellView.swift
+++ b/TripLog/TripLog/Feat-Jeff/CashBookList/View/AddCellView.swift
@@ -1,5 +1,5 @@
 //
-//  EmptyListCollectionViewCell.swift
+//  AddCellView.swift
 //  TripLog
 //
 //  Created by jae hoon lee on 1/22/25.
@@ -7,11 +7,16 @@
 import UIKit
 import SnapKit
 import Then
+import RxCocoa
+import RxSwift
 
-final class EmptyListCollectionViewCell: UICollectionViewCell {
-    static let id = "EmptyListCollectionViewCell"
+final class AddCellView: UIView {
+    
+    var disposeBag = DisposeBag()
+    let addButtonTapped = PublishRelay<Void>()
     
     private let addNameLabel = UILabel().then {
+        $0.text = "여행 추가하기"
         $0.textAlignment = .left
         $0.font = UIFont.SCDream(size: .headline, weight: .medium)
     }
@@ -20,9 +25,12 @@ final class EmptyListCollectionViewCell: UICollectionViewCell {
         $0.setImage(UIImage(systemName: "plus"), for: .normal)
         $0.tintColor = UIColor.Light.r200
     }
-  
+    
     override init(frame: CGRect) {
         super.init(frame: frame)
+        addButton.rx.tap
+            .bind(to: addButtonTapped)
+            .disposed(by: disposeBag)
         
         setupUI()
         setupShadow()
@@ -34,14 +42,12 @@ final class EmptyListCollectionViewCell: UICollectionViewCell {
     
     /// setupUI
     private func setupUI() {
-        addNameLabel.text = "여행 추가하기"
         backgroundColor = .white
-        self.frame.size.height = 150
         
         [
             addButton,
             addNameLabel
-        ].forEach { contentView.addSubview($0) }
+        ].forEach { addSubview($0) }
         
         addNameLabel.snp.makeConstraints {
             $0.top.equalToSuperview().offset(20)
@@ -55,8 +61,8 @@ final class EmptyListCollectionViewCell: UICollectionViewCell {
         }
     }
     
-    /// 셀에 그림자 추가(contentView)
-    func setupShadow() {
+    /// 셀에 그림자 추가
+    private func setupShadow() {
         layer.borderWidth = 0.2
         layer.borderColor = UIColor.lightGray.cgColor
         
@@ -67,5 +73,4 @@ final class EmptyListCollectionViewCell: UICollectionViewCell {
         layer.shadowRadius = 4
         layer.masksToBounds = false
     }
-    
 }

--- a/TripLog/TripLog/Feat-Jeff/CashBookList/View/AddCellView.swift
+++ b/TripLog/TripLog/Feat-Jeff/CashBookList/View/AddCellView.swift
@@ -21,16 +21,13 @@ final class AddCellView: UIView {
         $0.font = UIFont.SCDream(size: .headline, weight: .medium)
     }
     
-    private let addButton = UIButton().then {
+    let addButton = UIButton().then {
         $0.setImage(UIImage(systemName: "plus"), for: .normal)
         $0.tintColor = UIColor.Light.r200
     }
     
     override init(frame: CGRect) {
         super.init(frame: frame)
-        addButton.rx.tap
-            .bind(to: addButtonTapped)
-            .disposed(by: disposeBag)
         
         setupUI()
         setupShadow()

--- a/TripLog/TripLog/Feat-Jeff/CashBookList/View/CashBookListViewController.swift
+++ b/TripLog/TripLog/Feat-Jeff/CashBookList/View/CashBookListViewController.swift
@@ -7,10 +7,16 @@
 import UIKit
 import SnapKit
 import Then
+import RxDataSources
+import RxSwift
 
-class CashBookListViewController: UIViewController {
+final class CashBookListViewController: UIViewController {
     
-    /// titleLabel
+    private let disposeBag = DisposeBag()
+    private let viewModel = CashBookListViewModel()
+    
+    private let viewWillAppearSubject = PublishSubject<Void>()
+    
     private let titleLabel = UILabel().then {
         $0.text = "나의 가계부"
         $0.font = UIFont.SCDream(size: .title, weight: .bold)
@@ -18,29 +24,84 @@ class CashBookListViewController: UIViewController {
         $0.backgroundColor = .white
     }
     
-    /// collectionView
-    private let listCollectionView = UICollectionView(
+    lazy var listCollectionView = UICollectionView(
         frame: .zero,
-        collectionViewLayout: UICollectionViewFlowLayout()
+        collectionViewLayout: listCollectionViewLayout()
     ).then {
         $0.backgroundColor = .white
     }
     
     /// 임시 버튼
     private let button = UIButton().then {
-        $0.backgroundColor = .white
+        $0.backgroundColor = .lightGray
         $0.setTitle("버튼", for: .normal)
         $0.setTitleColor(.red, for: .normal)
     }
     
     override func viewDidLoad() {
         super.viewDidLoad()
+        view.backgroundColor = .white
+        
+        listCollectionView.register(EmptyListCollectionViewCell.self, forCellWithReuseIdentifier: EmptyListCollectionViewCell.id)
+        listCollectionView.register(ListCollectionViewCell.self, forCellWithReuseIdentifier: ListCollectionViewCell.id)
         
         setupUI()
+        bind()
     }
     
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        viewWillAppearSubject.onNext(())
+    }
+    
+    /// Rx를 이용한 dataSource구현(타입에는 SectionModelType인 SectionOfListCellData으로 정의)
+    /// RxCollectionViewSectionedAnimatedDataSource -> // 변화....
+    private let dataSource = RxCollectionViewSectionedReloadDataSource<SectionOfListCellData>(
+        configureCell: {dataSource, collectionView, indexPath, item in
+            
+            let sectionType = dataSource.sectionModels[indexPath.section].state
+            switch sectionType {
+                // 첫 번째 섹션: emptyState 셀
+            case .emptyState:
+                guard let cell = collectionView.dequeueReusableCell(
+                    withReuseIdentifier: EmptyListCollectionViewCell.id,
+                    for: indexPath
+                ) as? EmptyListCollectionViewCell else {
+                    fatalError("셀을 불러오지 못함")
+                }
+                return cell
+                
+                // 두 번째 섹션: existState 셀
+            case .existState:
+                guard let cell = collectionView.dequeueReusableCell(
+                    withReuseIdentifier: ListCollectionViewCell.id,
+                    for: indexPath
+                ) as? ListCollectionViewCell else {
+                    fatalError("셀을 불러오지 못함")
+                }
+                cell.configureCell(data: item)
+                return cell
+            }
+        }
+    )
+    
+    func bind() {
+        let input = CashBookListViewModel.Input(
+            callViewWillAppear: viewWillAppearSubject.asObservable(),
+            buttonTapped: button.rx.tap.asObservable()
+        )
+        
+        let output = viewModel.transform(input: input)
+        
+        output.updatedData
+            .drive(listCollectionView.rx.items(dataSource: dataSource))
+            .disposed(by: disposeBag)
+    }
+    
+    /// ViewController 레이아웃
     private func setupUI() {
         let safeArea = view.safeAreaLayoutGuide
+        navigationController?.navigationBar.isHidden = true
         
         [
             titleLabel,
@@ -48,20 +109,17 @@ class CashBookListViewController: UIViewController {
             button
         ].forEach { view.addSubview($0) }
         
-        /// titleLabel layout
         titleLabel.snp.makeConstraints {
             $0.top.equalTo(safeArea.snp.top).offset(12)
             $0.horizontalEdges.equalToSuperview().inset(16)
             $0.height.equalTo(21)
         }
         
-        /// collectionView layout
         listCollectionView.snp.makeConstraints {
             $0.top.equalTo(titleLabel.snp.bottom).offset(16)
             $0.horizontalEdges.equalToSuperview().inset(16)
         }
         
-        /// buttom layout
         button.snp.makeConstraints {
             $0.top.equalTo(listCollectionView.snp.bottom).offset(18)
             $0.horizontalEdges.equalToSuperview().inset(16)
@@ -69,4 +127,25 @@ class CashBookListViewController: UIViewController {
             $0.height.equalTo(60)
         }
     }
+    
+    /// CollectionView Composition Layout (compositional.list 넣어서 스와이프 부드러운 모션)
+    private func listCollectionViewLayout() -> UICollectionViewLayout{
+        let itemSize = NSCollectionLayoutSize(
+            widthDimension: .fractionalWidth(1.0),
+            heightDimension: .fractionalHeight(1.0))
+        
+        let item = NSCollectionLayoutItem(layoutSize: itemSize)
+        
+        let groupSize = NSCollectionLayoutSize(
+            widthDimension: .fractionalWidth(1.0),
+            heightDimension: .absolute(153))
+        
+        let group = NSCollectionLayoutGroup.vertical(layoutSize: groupSize, subitems: [item])
+        
+        let section = NSCollectionLayoutSection(group: group)
+        section.contentInsets = NSDirectionalEdgeInsets(top: 2, leading: 2, bottom: 10, trailing: 2)
+        
+        return UICollectionViewCompositionalLayout(section: section)
+    }
 }
+

--- a/TripLog/TripLog/Feat-Jeff/CashBookList/View/CashBookListViewController.swift
+++ b/TripLog/TripLog/Feat-Jeff/CashBookList/View/CashBookListViewController.swift
@@ -28,11 +28,11 @@ final class CashBookListViewController: UIViewController {
         $0.backgroundColor = .white
     }
     
-    lazy var listCollectionView = UICollectionView(
+    private lazy var listCollectionView = UICollectionView(
         frame: .zero,
         collectionViewLayout: listCollectionViewLayout()
     ).then {
-        $0.backgroundColor = .white
+        $0.backgroundColor = .clear
         $0.register(ListCollectionViewCell.self, forCellWithReuseIdentifier: ListCollectionViewCell.id)
     }
     
@@ -60,7 +60,7 @@ final class CashBookListViewController: UIViewController {
                 ) as? ListCollectionViewCell else {
                     return UICollectionViewCell()
                 }
-                cell.configureCell(data: item)
+                cell.configureCell(data: item) 
                 return cell
             }
         )
@@ -81,7 +81,7 @@ final class CashBookListViewController: UIViewController {
         super.viewWillAppear(animated)
         viewWillAppearSubject.onNext(())
     }
- 
+    
 }
 
 //MARK: - Method
@@ -152,8 +152,9 @@ extension CashBookListViewController {
         
         output.showAddListModal
             .asSignal(onErrorSignalWith: .empty())
-            .emit(onNext: {
-                ModalViewManager.showModal(on: self, state: .createNewCashBook)
+            .withUnretained(self)
+            .emit(onNext: { owner, _ in
+                ModalViewManager.showModal(on: owner, state: .createNewCashBook)
             })
             .disposed(by: disposeBag)
         

--- a/TripLog/TripLog/Feat-Jeff/CashBookList/View/CashBookListViewController.swift
+++ b/TripLog/TripLog/Feat-Jeff/CashBookList/View/CashBookListViewController.swift
@@ -32,7 +32,7 @@ final class CashBookListViewController: UIViewController {
     }
     
     /// 임시 버튼
-    private let button = UIButton().then {
+    private let testButton = UIButton().then {
         $0.backgroundColor = .lightGray
         $0.setTitle("버튼", for: .normal)
         $0.setTitleColor(.red, for: .normal)
@@ -41,6 +41,8 @@ final class CashBookListViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         view.backgroundColor = .white
+        
+       
         
         listCollectionView.register(EmptyListCollectionViewCell.self, forCellWithReuseIdentifier: EmptyListCollectionViewCell.id)
         listCollectionView.register(ListCollectionViewCell.self, forCellWithReuseIdentifier: ListCollectionViewCell.id)
@@ -88,7 +90,7 @@ final class CashBookListViewController: UIViewController {
     func bind() {
         let input = CashBookListViewModel.Input(
             callViewWillAppear: viewWillAppearSubject.asObservable(),
-            buttonTapped: button.rx.tap.asObservable()
+            buttonTapped: testButton.rx.tap.asObservable()
         )
         
         let output = viewModel.transform(input: input)
@@ -106,7 +108,7 @@ final class CashBookListViewController: UIViewController {
         [
             titleLabel,
             listCollectionView,
-            button
+            testButton
         ].forEach { view.addSubview($0) }
         
         titleLabel.snp.makeConstraints {
@@ -120,7 +122,7 @@ final class CashBookListViewController: UIViewController {
             $0.horizontalEdges.equalToSuperview().inset(16)
         }
         
-        button.snp.makeConstraints {
+        testButton.snp.makeConstraints {
             $0.top.equalTo(listCollectionView.snp.bottom).offset(18)
             $0.horizontalEdges.equalToSuperview().inset(16)
             $0.bottom.equalTo(safeArea.snp.bottom).offset(-18)
@@ -128,24 +130,84 @@ final class CashBookListViewController: UIViewController {
         }
     }
     
-    /// CollectionView Composition Layout (compositional.list 넣어서 스와이프 부드러운 모션)
-    private func listCollectionViewLayout() -> UICollectionViewLayout{
-        let itemSize = NSCollectionLayoutSize(
-            widthDimension: .fractionalWidth(1.0),
-            heightDimension: .fractionalHeight(1.0))
+    
+    /// CollectionView Layout(UICollectionLayoutListConfiguration)
+    private func listCollectionViewLayout() -> UICollectionViewLayout {
+        let layout = UICollectionViewCompositionalLayout { sectionIndex, layoutEnvironment -> NSCollectionLayoutSection in
+            var configuration = UICollectionLayoutListConfiguration(appearance: .plain)
+            
+            switch sectionIndex {
+            case 0:
+                configuration.trailingSwipeActionsConfigurationProvider = { indexPath in
+                    let deletAction = UIContextualAction(style: .destructive, title: "삭제") { _, _, completion in
+                        print("삭제")
+                        completion(true)
+                    }
+                    return UISwipeActionsConfiguration(actions: [deletAction])
+                }
+                configuration.leadingSwipeActionsConfigurationProvider = { indexPath in
+                    let editAction = UIContextualAction(style: .normal, title: "수정") { _, _, completion in
+                        print("수정")
+                        completion(true)
+                    }
+                    return UISwipeActionsConfiguration(actions: [editAction])
+                }
+                
+            case 1:
+                configuration.trailingSwipeActionsConfigurationProvider = { indexPath in
+                    let deletAction = UIContextualAction(style: .destructive, title: "삭제") { _, _, completion in
+                        print("삭제")
+                        completion(true)
+                    }
+                    return UISwipeActionsConfiguration(actions: [deletAction])
+                }
+                configuration.leadingSwipeActionsConfigurationProvider = { indexPath in
+                    let editAction = UIContextualAction(style: .normal, title: "수정") { _, _, completion in
+                        print("수정")
+                        completion(true)
+                    }
+                    return UISwipeActionsConfiguration(actions: [editAction])
+                }
+            default:
+                break
+            }
+            
+            let section = NSCollectionLayoutSection.list(using: configuration, layoutEnvironment: layoutEnvironment)
+            section.contentInsets = NSDirectionalEdgeInsets(top: 2, leading: 2, bottom: 10, trailing: 2)
+            return section
+        }
         
-        let item = NSCollectionLayoutItem(layoutSize: itemSize)
-        
-        let groupSize = NSCollectionLayoutSize(
-            widthDimension: .fractionalWidth(1.0),
-            heightDimension: .absolute(153))
-        
-        let group = NSCollectionLayoutGroup.vertical(layoutSize: groupSize, subitems: [item])
-        
-        let section = NSCollectionLayoutSection(group: group)
-        section.contentInsets = NSDirectionalEdgeInsets(top: 2, leading: 2, bottom: 10, trailing: 2)
-        
-        return UICollectionViewCompositionalLayout(section: section)
+        return layout
     }
+    
+    /// CollectionView Composition Layout (compositional.list 넣어서 스와이프 부드러운 모션)
+//    private func listCollectionViewLayout() -> UICollectionViewLayout{
+//        let itemSize = NSCollectionLayoutSize(
+//            widthDimension: .fractionalWidth(1.0),
+//            heightDimension: .fractionalHeight(1.0))
+//        
+//        let item = NSCollectionLayoutItem(layoutSize: itemSize)
+//        
+//        let groupSize = NSCollectionLayoutSize(
+//            widthDimension: .fractionalWidth(1.0),
+//            heightDimension: .absolute(153))
+//        
+//        let group = NSCollectionLayoutGroup.vertical(layoutSize: groupSize, subitems: [item])
+//        
+//        let section = NSCollectionLayoutSection(group: group)
+//        section.contentInsets = NSDirectionalEdgeInsets(top: 2, leading: 2, bottom: 10, trailing: 2)
+//        
+//        return UICollectionViewCompositionalLayout(section: section)
+//    }
 }
 
+/*
+ var leadingSwipeActionsConfigurationProvider: UICollectionLayoutListConfiguration.SwipeActionsConfigurationProvider?
+ 셀의 앞쪽 가장자리를 스와이프할 때 표시할 작업 세트를 제공하는 클로저입니다.
+ var trailingSwipeActionsConfigurationProvider: UICollectionLayoutListConfiguration.SwipeActionsConfigurationProvider?
+ */
+
+/// 어떻게 해야 첫번째 셀을 지울 수 있을지에 대해서 고민
+/// 가로 스크롤할 때 기능 구현
+/// 버튼 연결
+/// pr올리는게 목표

--- a/TripLog/TripLog/Feat-Jeff/CashBookList/View/CashBookListViewController.swift
+++ b/TripLog/TripLog/Feat-Jeff/CashBookList/View/CashBookListViewController.swift
@@ -5,8 +5,8 @@
 //  Created by jae hoon lee on 1/20/25.
 //
 import UIKit
-import Then
 import SnapKit
+import Then
 
 class CashBookListViewController: UIViewController {
     

--- a/TripLog/TripLog/Feat-Jeff/CashBookList/View/CashBookListViewController.swift
+++ b/TripLog/TripLog/Feat-Jeff/CashBookList/View/CashBookListViewController.swift
@@ -1,0 +1,72 @@
+//
+//  CashBookListViewController.swift
+//  TripLog
+//
+//  Created by jae hoon lee on 1/20/25.
+//
+import UIKit
+import Then
+import SnapKit
+
+class CashBookListViewController: UIViewController {
+    
+    /// titleLabel
+    private let titleLabel = UILabel().then {
+        $0.text = "나의 가계부"
+        $0.font = UIFont.SCDream(size: .title, weight: .bold)
+        $0.textAlignment = .left
+        $0.backgroundColor = .white
+    }
+    
+    /// collectionView
+    private let listCollectionView = UICollectionView(
+        frame: .zero,
+        collectionViewLayout: UICollectionViewFlowLayout()
+    ).then {
+        $0.backgroundColor = .white
+    }
+    
+    /// 임시 버튼
+    private let button = UIButton().then {
+        $0.backgroundColor = .white
+        $0.setTitle("버튼", for: .normal)
+        $0.setTitleColor(.red, for: .normal)
+    }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        setupUI()
+    }
+    
+    private func setupUI() {
+        let safeArea = view.safeAreaLayoutGuide
+        
+        [
+            titleLabel,
+            listCollectionView,
+            button
+        ].forEach { view.addSubview($0) }
+        
+        /// titleLabel layout
+        titleLabel.snp.makeConstraints {
+            $0.top.equalTo(safeArea.snp.top).offset(12)
+            $0.horizontalEdges.equalToSuperview().inset(16)
+            $0.height.equalTo(21)
+        }
+        
+        /// collectionView layout
+        listCollectionView.snp.makeConstraints {
+            $0.top.equalTo(titleLabel.snp.bottom).offset(16)
+            $0.horizontalEdges.equalToSuperview().inset(16)
+        }
+        
+        /// buttom layout
+        button.snp.makeConstraints {
+            $0.top.equalTo(listCollectionView.snp.bottom).offset(18)
+            $0.horizontalEdges.equalToSuperview().inset(16)
+            $0.bottom.equalTo(safeArea.snp.bottom).offset(-18)
+            $0.height.equalTo(60)
+        }
+    }
+}

--- a/TripLog/TripLog/Feat-Jeff/CashBookList/View/EmptyListCollectionViewCell.swift
+++ b/TripLog/TripLog/Feat-Jeff/CashBookList/View/EmptyListCollectionViewCell.swift
@@ -1,0 +1,71 @@
+//
+//  EmptyListCollectionViewCell.swift
+//  TripLog
+//
+//  Created by jae hoon lee on 1/22/25.
+//
+import UIKit
+import SnapKit
+import Then
+
+final class EmptyListCollectionViewCell: UICollectionViewCell {
+    static let id = "EmptyListCollectionViewCell"
+    
+    // 여행 추가하기 Label
+    private let addNameLabel = UILabel().then {
+        $0.textAlignment = .left
+        $0.font = UIFont.SCDream(size: .headline, weight: .medium)
+    }
+    
+    // "+" Button
+    private let addButton = UIButton().then {
+        $0.setImage(UIImage(systemName: "plus"), for: .normal)
+        $0.tintColor = UIColor.Light.r200
+    }
+  
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        setupUI()
+        setupShadow()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    /// setupUI
+    private func setupUI() {
+        addNameLabel.text = "여행 추가하기"
+        backgroundColor = .white
+        
+        [
+            addButton,
+            addNameLabel
+        ].forEach { contentView.addSubview($0) }
+        
+        addNameLabel.snp.makeConstraints {
+            $0.top.equalToSuperview().offset(20)
+            $0.horizontalEdges.equalToSuperview().inset(24)
+            $0.height.equalTo(20)
+        }
+        
+        addButton.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+        }
+    }
+    
+    /// 셀에 그림자 추가(contentView)
+    func setupShadow() {
+        layer.borderWidth = 0.2
+        layer.borderColor = UIColor.lightGray.cgColor
+        
+        layer.cornerRadius = 8
+        layer.shadowColor = UIColor.black.cgColor
+        layer.shadowOpacity = 0.2
+        layer.shadowOffset = CGSize(width: 0, height: 1)
+        layer.shadowRadius = 4
+        layer.masksToBounds = false
+    }
+    
+}

--- a/TripLog/TripLog/Feat-Jeff/CashBookList/View/EmptyListCollectionViewCell.swift
+++ b/TripLog/TripLog/Feat-Jeff/CashBookList/View/EmptyListCollectionViewCell.swift
@@ -11,13 +11,11 @@ import Then
 final class EmptyListCollectionViewCell: UICollectionViewCell {
     static let id = "EmptyListCollectionViewCell"
     
-    // 여행 추가하기 Label
     private let addNameLabel = UILabel().then {
         $0.textAlignment = .left
         $0.font = UIFont.SCDream(size: .headline, weight: .medium)
     }
     
-    // "+" Button
     private let addButton = UIButton().then {
         $0.setImage(UIImage(systemName: "plus"), for: .normal)
         $0.tintColor = UIColor.Light.r200

--- a/TripLog/TripLog/Feat-Jeff/CashBookList/View/EmptyListCollectionViewCell.swift
+++ b/TripLog/TripLog/Feat-Jeff/CashBookList/View/EmptyListCollectionViewCell.swift
@@ -36,6 +36,7 @@ final class EmptyListCollectionViewCell: UICollectionViewCell {
     private func setupUI() {
         addNameLabel.text = "여행 추가하기"
         backgroundColor = .white
+        self.frame.size.height = 150
         
         [
             addButton,
@@ -50,6 +51,7 @@ final class EmptyListCollectionViewCell: UICollectionViewCell {
         
         addButton.snp.makeConstraints {
             $0.edges.equalToSuperview()
+            $0.height.equalTo(152)
         }
     }
     

--- a/TripLog/TripLog/Feat-Jeff/CashBookList/View/ListCollectionViewCell.swift
+++ b/TripLog/TripLog/Feat-Jeff/CashBookList/View/ListCollectionViewCell.swift
@@ -104,7 +104,7 @@ final class ListCollectionViewCell: UICollectionViewCell {
         layer.masksToBounds = false
     }
    
-    /// 데이터에 저장된 값으로 셀에 주입
+    /// 데이터에 저장된 값으로 UI update
     func configureCell(data: ListCellData) {
         tripNameLabel.text = data.tripName
         noteLabel.text = data.note

--- a/TripLog/TripLog/Feat-Jeff/CashBookList/View/ListCollectionViewCell.swift
+++ b/TripLog/TripLog/Feat-Jeff/CashBookList/View/ListCollectionViewCell.swift
@@ -4,12 +4,11 @@
 //
 //  Created by jae hoon lee on 1/20/25.
 //
-
 import UIKit
 import SnapKit
 import Then
 
-class ListCollectionViewCell: UICollectionViewCell {
+final class ListCollectionViewCell: UICollectionViewCell {
     static let id = "ListCollectionViewCell"
     
     private var tripNameLabel = UILabel().then {
@@ -52,28 +51,7 @@ class ListCollectionViewCell: UICollectionViewCell {
         fatalError("init(coder:) has not been implemented")
     }
     
-    /// 셀에 그림자 추가
-    func setupShadow() {
-        layer.borderWidth = 0.2
-        layer.borderColor = UIColor.lightGray.cgColor
-        
-        layer.cornerRadius = 8
-        layer.shadowColor = UIColor.black.cgColor
-        layer.shadowOpacity = 0.2
-        layer.shadowOffset = CGSize(width: 0, height: 1)
-        layer.shadowRadius = 4
-        layer.masksToBounds = false
-    }
-   
-    /// 데이터에 저장된 값을 이용해 셀에 주입
-    func configureCell(data: ListCellData) {
-        tripNameLabel.text = data.tripName
-        noteLabel.text = data.note
-        bugetLabel.text = "💰 \(PriceFormatModel.wonFormat(Int(data.buget)))"
-        periodLabel.text = "🗓️ \(data.departure) - \(data.homecoming)"
-    }
-    
-    /// 데이터가 있는 경우의 setupUI
+    /// setupUI
     private func setupUI() {
         backgroundColor = .white
         
@@ -100,4 +78,26 @@ class ListCollectionViewCell: UICollectionViewCell {
             $0.bottom.equalToSuperview().offset(-20)
         }
     }
+    
+    /// 셀에 그림자 추가(ContentView)
+    private func setupShadow() {
+        layer.borderWidth = 0.2
+        layer.borderColor = UIColor.lightGray.cgColor
+        
+        layer.cornerRadius = 8
+        layer.shadowColor = UIColor.black.cgColor
+        layer.shadowOpacity = 0.2
+        layer.shadowOffset = CGSize(width: 0, height: 1)
+        layer.shadowRadius = 4
+        layer.masksToBounds = false
+    }
+   
+    /// 데이터에 저장된 값으로 셀에 주입
+    func configureCell(data: ListCellData) {
+        tripNameLabel.text = data.tripName
+        noteLabel.text = data.note
+        bugetLabel.text = "💰 \(PriceFormatModel.wonFormat(Int(data.buget)))"
+        periodLabel.text = "🗓️ \(data.departure) - \(data.homecoming)"
+    }
+    
 }

--- a/TripLog/TripLog/Feat-Jeff/CashBookList/View/ListCollectionViewCell.swift
+++ b/TripLog/TripLog/Feat-Jeff/CashBookList/View/ListCollectionViewCell.swift
@@ -11,24 +11,28 @@ import Then
 final class ListCollectionViewCell: UICollectionViewCell {
     static let id = "ListCollectionViewCell"
     
-    private var tripNameLabel = UILabel().then {
-        $0.numberOfLines = 2
+    private let tripNameLabel = UILabel().then {
+        $0.numberOfLines = 1
+        $0.adjustsFontSizeToFitWidth = true
+        $0.minimumScaleFactor = 0.7
         $0.textAlignment = .left
         $0.font = UIFont.SCDream(size: .headline, weight: .medium)
     }
     
-    private var noteLabel = UILabel().then {
-        $0.numberOfLines = 2
+    private let noteLabel = UILabel().then {
+        $0.numberOfLines = 1
+        $0.adjustsFontSizeToFitWidth = true
+        $0.minimumScaleFactor = 0.5
         $0.textAlignment = .left
         $0.font = UIFont.SCDream(size: .body, weight: .regular)
     }
     
-    private var bugetLabel = UILabel().then {
+    private let bugetLabel = UILabel().then {
         $0.textAlignment = .left
         $0.font = UIFont.SCDream(size: .body, weight: .regular)
     }
     
-    private var periodLabel = UILabel().then {
+    private let periodLabel = UILabel().then {
         $0.textAlignment = .left
         $0.font = UIFont.SCDream(size: .body, weight: .regular)
     }
@@ -44,14 +48,21 @@ final class ListCollectionViewCell: UICollectionViewCell {
         super.init(frame: frame)
         
         setupUI()
+        setupConstraints()
         setupShadow()
     }
-
+    
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
     
-    /// setupUI
+}
+
+//MARK: - Method
+
+extension ListCollectionViewCell {
+    
+    /// setup UI
     private func setupUI() {
         backgroundColor = .white
         
@@ -65,7 +76,10 @@ final class ListCollectionViewCell: UICollectionViewCell {
             tripNameLabel,
             verticalStackView
         ].forEach { contentView.addSubview($0) }
-        
+    }
+    
+    /// setup Constraints
+    private func setupConstraints() {
         tripNameLabel.snp.makeConstraints {
             $0.top.equalToSuperview().offset(20)
             $0.horizontalEdges.equalTo(contentView.snp.horizontalEdges).inset(24)
@@ -103,7 +117,7 @@ final class ListCollectionViewCell: UICollectionViewCell {
         layer.shadowRadius = 4
         layer.masksToBounds = false
     }
-   
+    
     /// 데이터에 저장된 값으로 UI update
     func configureCell(data: ListCellData) {
         tripNameLabel.text = data.tripName

--- a/TripLog/TripLog/Feat-Jeff/CashBookList/View/ListCollectionViewCell.swift
+++ b/TripLog/TripLog/Feat-Jeff/CashBookList/View/ListCollectionViewCell.swift
@@ -56,15 +56,24 @@ final class ListCollectionViewCell: UICollectionViewCell {
         fatalError("init(coder:) has not been implemented")
     }
     
+    /// 데이터에 저장된 값으로 UI update
+    func configureCell(data: ListCellData) {
+        tripNameLabel.text = data.tripName
+        noteLabel.text = data.note
+        bugetLabel.text = "💰 \(NumberFormatter.wonFormat(Int(data.buget)))"
+        periodLabel.text = "🗓️ \(data.departure) - \(data.homecoming)"
+    }
+    
+    
 }
 
 //MARK: - Method
 
-extension ListCollectionViewCell {
+private extension ListCollectionViewCell {
     
     /// setup UI
-    private func setupUI() {
-        backgroundColor = .white
+    func setupUI() {
+        backgroundColor = UIColor(resource: .Light.base)
         
         [
             noteLabel,
@@ -79,7 +88,7 @@ extension ListCollectionViewCell {
     }
     
     /// setup Constraints
-    private func setupConstraints() {
+    func setupConstraints() {
         tripNameLabel.snp.makeConstraints {
             $0.top.equalToSuperview().offset(20)
             $0.horizontalEdges.equalTo(contentView.snp.horizontalEdges).inset(24)
@@ -106,7 +115,7 @@ extension ListCollectionViewCell {
     }
     
     /// 셀에 그림자 추가(ContentView)
-    private func setupShadow() {
+    func setupShadow() {
         layer.borderWidth = 0.2
         layer.borderColor = UIColor.lightGray.cgColor
         
@@ -116,14 +125,6 @@ extension ListCollectionViewCell {
         layer.shadowOffset = CGSize(width: 0, height: 1)
         layer.shadowRadius = 4
         layer.masksToBounds = false
-    }
-    
-    /// 데이터에 저장된 값으로 UI update
-    func configureCell(data: ListCellData) {
-        tripNameLabel.text = data.tripName
-        noteLabel.text = data.note
-        bugetLabel.text = "💰 \(PriceFormatModel.wonFormat(Int(data.buget)))"
-        periodLabel.text = "🗓️ \(data.departure) - \(data.homecoming)"
     }
     
 }

--- a/TripLog/TripLog/Feat-Jeff/CashBookList/View/ListCollectionViewCell.swift
+++ b/TripLog/TripLog/Feat-Jeff/CashBookList/View/ListCollectionViewCell.swift
@@ -1,0 +1,119 @@
+//
+//  ListCollectionViewCell.swift
+//  TripLog
+//
+//  Created by jae hoon lee on 1/20/25.
+//
+
+import UIKit
+import SnapKit
+import Then
+
+class ListCollectionViewCell: UICollectionViewCell {
+    
+    // 더미데이터
+    private var country: String = "일본, 미국, 하와이, 스위스, 체코"
+    private var buget: Int = 26000000
+    private var startDate: String = "2025.05.12"
+    private var endDate: String = "2025.06.13"
+    
+    private let tripNameLabel = UILabel().then {
+        $0.numberOfLines = 2
+        $0.text = "겨울방학 여행 2024"
+        $0.textAlignment = .left
+        $0.font = UIFont.SCDream(size: .headline, weight: .medium)
+    }
+    
+    lazy var countryNameLabel = UILabel().then {
+        $0.numberOfLines = 2
+        $0.text = "\(country)"
+        $0.textAlignment = .left
+        $0.font = UIFont.SCDream(size: .body, weight: .regular)
+    }
+    
+    lazy var bugetLabel = UILabel().then {
+        $0.text = "💰 \(PriceFormatModel.wonFormat(buget))"
+        $0.textAlignment = .left
+        $0.font = UIFont.SCDream(size: .body, weight: .regular)
+    }
+    
+    lazy var periodLabel = UILabel().then {
+        $0.text = "🗓️ \(startDate) - \(endDate)"
+        $0.textAlignment = .left
+        $0.font = UIFont.SCDream(size: .body, weight: .regular)
+    }
+    
+    private let verticalStackView = UIStackView().then {
+        $0.alignment = .fill
+        $0.distribution = .fillEqually
+        $0.axis = .vertical
+        $0.spacing = 8
+    }
+    
+    private let addImageView = UIImageView().then {
+        $0.image = UIImage(systemName: "plus")
+        $0.tintColor = UIColor.Light.r200
+    }
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        emptySetupUI()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    /// 저장된 데이터가 없는 경우 UI setup
+    private func emptySetupUI() {
+        let safeArea = self.safeAreaLayoutGuide
+        backgroundColor = .white
+        
+        [
+            tripNameLabel,
+            addImageView
+        ].forEach { contentView.addSubview($0) }
+        
+        tripNameLabel.snp.makeConstraints {
+            $0.top.equalToSuperview().offset(20)
+            $0.horizontalEdges.equalTo(safeArea.snp.horizontalEdges).inset(24)
+            $0.height.equalTo(20)
+        }
+        
+        addImageView.snp.makeConstraints {
+            $0.center.equalToSuperview()
+            $0.height.width.equalTo(24)
+        }
+    }
+    
+    /// 데이터가 있는 경우의 UI setup
+    private func setupUI() {
+        let safeArea = self.safeAreaLayoutGuide
+        backgroundColor = .white
+        
+        [
+            countryNameLabel,
+            bugetLabel,
+            periodLabel
+        ].forEach { verticalStackView.addArrangedSubview($0) }
+        
+        [
+            tripNameLabel,
+            verticalStackView
+        ].forEach { contentView.addSubview($0) }
+        
+        tripNameLabel.snp.makeConstraints {
+            $0.top.equalToSuperview().offset(20)
+            $0.horizontalEdges.equalTo(safeArea.snp.horizontalEdges).inset(24)
+            $0.height.equalTo(20)
+        }
+        
+        verticalStackView.snp.makeConstraints {
+            $0.top.equalTo(tripNameLabel.snp.bottom).offset(16)
+            $0.horizontalEdges.equalTo(safeArea.snp.horizontalEdges).inset(24)
+            $0.bottom.equalToSuperview().offset(-20)
+        }
+    }
+}
+

--- a/TripLog/TripLog/Feat-Jeff/CashBookList/View/ListCollectionViewCell.swift
+++ b/TripLog/TripLog/Feat-Jeff/CashBookList/View/ListCollectionViewCell.swift
@@ -10,6 +10,7 @@ import SnapKit
 import Then
 
 class ListCollectionViewCell: UICollectionViewCell {
+    static let id = "ListCollectionViewCell"
     
     // 더미데이터
     private var country: String = "일본, 미국, 하와이, 스위스, 체코"
@@ -24,20 +25,20 @@ class ListCollectionViewCell: UICollectionViewCell {
         $0.font = UIFont.SCDream(size: .headline, weight: .medium)
     }
     
-    lazy var countryNameLabel = UILabel().then {
+    private lazy var countryNameLabel = UILabel().then {
         $0.numberOfLines = 2
         $0.text = "\(country)"
         $0.textAlignment = .left
         $0.font = UIFont.SCDream(size: .body, weight: .regular)
     }
     
-    lazy var bugetLabel = UILabel().then {
+    private lazy var bugetLabel = UILabel().then {
         $0.text = "💰 \(PriceFormatModel.wonFormat(buget))"
         $0.textAlignment = .left
         $0.font = UIFont.SCDream(size: .body, weight: .regular)
     }
     
-    lazy var periodLabel = UILabel().then {
+    private lazy var periodLabel = UILabel().then {
         $0.text = "🗓️ \(startDate) - \(endDate)"
         $0.textAlignment = .left
         $0.font = UIFont.SCDream(size: .body, weight: .regular)
@@ -116,4 +117,3 @@ class ListCollectionViewCell: UICollectionViewCell {
         }
     }
 }
-

--- a/TripLog/TripLog/Feat-Jeff/CashBookList/View/ListCollectionViewCell.swift
+++ b/TripLog/TripLog/Feat-Jeff/CashBookList/View/ListCollectionViewCell.swift
@@ -77,6 +77,18 @@ final class ListCollectionViewCell: UICollectionViewCell {
             $0.horizontalEdges.equalToSuperview().inset(24)
             $0.bottom.equalToSuperview().offset(-20)
         }
+        
+        noteLabel.snp.makeConstraints {
+            $0.height.equalTo(20)
+        }
+        
+        bugetLabel.snp.makeConstraints {
+            $0.height.equalTo(20)
+        }
+        
+        periodLabel.snp.makeConstraints {
+            $0.height.equalTo(20)
+        }
     }
     
     /// 셀에 그림자 추가(ContentView)

--- a/TripLog/TripLog/Feat-Jeff/CashBookList/View/ListCollectionViewCell.swift
+++ b/TripLog/TripLog/Feat-Jeff/CashBookList/View/ListCollectionViewCell.swift
@@ -12,34 +12,24 @@ import Then
 class ListCollectionViewCell: UICollectionViewCell {
     static let id = "ListCollectionViewCell"
     
-    // 더미데이터
-    private var country: String = "일본, 미국, 하와이, 스위스, 체코"
-    private var buget: Int = 26000000
-    private var startDate: String = "2025.05.12"
-    private var endDate: String = "2025.06.13"
-    
-    private let tripNameLabel = UILabel().then {
+    private var tripNameLabel = UILabel().then {
         $0.numberOfLines = 2
-        $0.text = "겨울방학 여행 2024"
         $0.textAlignment = .left
         $0.font = UIFont.SCDream(size: .headline, weight: .medium)
     }
     
-    private lazy var countryNameLabel = UILabel().then {
+    private var noteLabel = UILabel().then {
         $0.numberOfLines = 2
-        $0.text = "\(country)"
         $0.textAlignment = .left
         $0.font = UIFont.SCDream(size: .body, weight: .regular)
     }
     
-    private lazy var bugetLabel = UILabel().then {
-        $0.text = "💰 \(PriceFormatModel.wonFormat(buget))"
+    private var bugetLabel = UILabel().then {
         $0.textAlignment = .left
         $0.font = UIFont.SCDream(size: .body, weight: .regular)
     }
     
-    private lazy var periodLabel = UILabel().then {
-        $0.text = "🗓️ \(startDate) - \(endDate)"
+    private var periodLabel = UILabel().then {
         $0.textAlignment = .left
         $0.font = UIFont.SCDream(size: .body, weight: .regular)
     }
@@ -51,50 +41,44 @@ class ListCollectionViewCell: UICollectionViewCell {
         $0.spacing = 8
     }
     
-    private let addImageView = UIImageView().then {
-        $0.image = UIImage(systemName: "plus")
-        $0.tintColor = UIColor.Light.r200
-    }
-    
     override init(frame: CGRect) {
         super.init(frame: frame)
         
-        emptySetupUI()
+        setupUI()
+        setupShadow()
     }
-    
+
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
     
-    /// 저장된 데이터가 없는 경우 UI setup
-    private func emptySetupUI() {
-        let safeArea = self.safeAreaLayoutGuide
-        backgroundColor = .white
+    /// 셀에 그림자 추가
+    func setupShadow() {
+        layer.borderWidth = 0.2
+        layer.borderColor = UIColor.lightGray.cgColor
         
-        [
-            tripNameLabel,
-            addImageView
-        ].forEach { contentView.addSubview($0) }
-        
-        tripNameLabel.snp.makeConstraints {
-            $0.top.equalToSuperview().offset(20)
-            $0.horizontalEdges.equalTo(safeArea.snp.horizontalEdges).inset(24)
-            $0.height.equalTo(20)
-        }
-        
-        addImageView.snp.makeConstraints {
-            $0.center.equalToSuperview()
-            $0.height.width.equalTo(24)
-        }
+        layer.cornerRadius = 8
+        layer.shadowColor = UIColor.black.cgColor
+        layer.shadowOpacity = 0.2
+        layer.shadowOffset = CGSize(width: 0, height: 1)
+        layer.shadowRadius = 4
+        layer.masksToBounds = false
+    }
+   
+    /// 데이터에 저장된 값을 이용해 셀에 주입
+    func configureCell(data: ListCellData) {
+        tripNameLabel.text = data.tripName
+        noteLabel.text = data.note
+        bugetLabel.text = "💰 \(PriceFormatModel.wonFormat(Int(data.buget)))"
+        periodLabel.text = "🗓️ \(data.departure) - \(data.homecoming)"
     }
     
-    /// 데이터가 있는 경우의 UI setup
+    /// 데이터가 있는 경우의 setupUI
     private func setupUI() {
-        let safeArea = self.safeAreaLayoutGuide
         backgroundColor = .white
         
         [
-            countryNameLabel,
+            noteLabel,
             bugetLabel,
             periodLabel
         ].forEach { verticalStackView.addArrangedSubview($0) }
@@ -106,13 +90,13 @@ class ListCollectionViewCell: UICollectionViewCell {
         
         tripNameLabel.snp.makeConstraints {
             $0.top.equalToSuperview().offset(20)
-            $0.horizontalEdges.equalTo(safeArea.snp.horizontalEdges).inset(24)
+            $0.horizontalEdges.equalTo(contentView.snp.horizontalEdges).inset(24)
             $0.height.equalTo(20)
         }
         
         verticalStackView.snp.makeConstraints {
             $0.top.equalTo(tripNameLabel.snp.bottom).offset(16)
-            $0.horizontalEdges.equalTo(safeArea.snp.horizontalEdges).inset(24)
+            $0.horizontalEdges.equalToSuperview().inset(24)
             $0.bottom.equalToSuperview().offset(-20)
         }
     }

--- a/TripLog/TripLog/Feat-Jeff/CashBookList/ViewModel/CashBookListViewModel.swift
+++ b/TripLog/TripLog/Feat-Jeff/CashBookList/ViewModel/CashBookListViewModel.swift
@@ -37,7 +37,8 @@ class CashBookListViewModel: ViewModelType {
                          buget: 5600000,
                          departure: "2025.12.12",
                          homecoming: "2025.12.21")
-        ]
+        ],
+        identity: UUID()
     )
     
     //    func deleteItem1(with id: UUID) {
@@ -65,11 +66,12 @@ class CashBookListViewModel: ViewModelType {
     
     func addItem(_ item: ListCellData) {
         items.append(item)
+        print("\(item)")
     }
     
     // 섹션을 하나로 고정으로 변경(deletcellrow) index로 지우기 -> 지워진거 이벤트 다시 방출
     func deleteItem(with id: UUID) {
-        if let index = items.firstIndex(where: { $0.id == id }) {
+        if let index = items.firstIndex(where: { $0.identity == id }) {
             items.remove(at: index)
         }
     }
@@ -77,7 +79,7 @@ class CashBookListViewModel: ViewModelType {
     func transform(input: Input) -> Output {
         let updatedData = itemsRelay
             .map { items in
-                [SectionOfListCellData(items: items)]
+                return [SectionOfListCellData(items: items, identity: UUID())]
             }.asDriver(onErrorJustReturn: [])
         
         let addCellViewHidden = itemsRelay

--- a/TripLog/TripLog/Feat-Jeff/CashBookList/ViewModel/CashBookListViewModel.swift
+++ b/TripLog/TripLog/Feat-Jeff/CashBookList/ViewModel/CashBookListViewModel.swift
@@ -12,7 +12,7 @@ class CashBookListViewModel: ViewModelType {
     // 임시 코어데이터 역할
     private let itemsRelay = BehaviorRelay<[ListCellData]>(value: [])
     
-    var items: [ListCellData] {
+    private(set) var items: [ListCellData] {
         get { itemsRelay.value }
         set { itemsRelay.accept(newValue) }
     }
@@ -103,7 +103,7 @@ class CashBookListViewModel: ViewModelType {
     }
     
     /// 임시 데이터 추가(itemsRelay)
-    func addItem(_ item: ListCellData) {
+    private func addItem(_ item: ListCellData) {
         items.append(item)
         print("\(item)")
     }

--- a/TripLog/TripLog/Feat-Jeff/CashBookList/ViewModel/CashBookListViewModel.swift
+++ b/TripLog/TripLog/Feat-Jeff/CashBookList/ViewModel/CashBookListViewModel.swift
@@ -1,0 +1,120 @@
+//
+//  CashBookListViewModel.swift
+//  TripLog
+//
+//  Created by jae hoon lee on 1/22/25.
+//
+import Foundation
+import RxSwift
+import RxCocoa
+
+class CashBookListViewModel: ViewModelType {
+    
+    var disposeBag = DisposeBag()
+  
+    /// Input
+    /// callViewWillAppear : ViewWillAppear 호출 시 방출
+    /// buttonTapped : 임시 버튼을 눌렀을 시 방출(임시)
+    struct Input {
+        let callViewWillAppear: Observable<Void>
+        let buttonTapped: Observable<Void>
+    }
+    
+    /// Output
+    /// updatedData : SectionOfListCellData로 업데이트(임시)
+    struct Output {
+        let updatedData: Driver<[SectionOfListCellData]>
+    }
+    
+    init() {}
+    
+    /// 임시 coreData역할 (초기값 이슈)
+    let coreDataValue = BehaviorSubject<[SectionOfListCellData]>(value: [
+        .init(state: .emptyState,
+              items: [ListCellData(tripName: "",
+                                   note: "",
+                                   buget: 0,
+                                   departure: "",
+                                   homecoming: "")])
+              ])
+    
+    // 더미데이터 추가를 위한 인덱스
+    private var currentIndex = 0
+    
+    // 더미데이터 값
+    private var dummyData = [
+        SectionOfListCellData(
+            state: .existState,
+            items: [
+                ListCellData(tripName: "여름방학 여행 2025",
+                             note: "일본, 미국, 하와이, 스위스, 체코",
+                             buget: 26000000,
+                             departure: "2025.05.12",
+                             homecoming: "2025.06.13")
+            ]
+        ),
+        SectionOfListCellData(
+            state: .existState,
+            items: [
+                ListCellData(tripName: "가을방학 여행 2025",
+                             note: "🇨🇮 🇩🇪 🇹🇷",
+                             buget: 3400000,
+                             departure: "2025.10.12",
+                             homecoming: "2025.10.23")
+            ]
+        ),
+        SectionOfListCellData(
+            state: .existState,
+            items: [
+                ListCellData(tripName: "겨을방학 여행 2025",
+                             note: "대만, 일본, 발리",
+                             buget: 5600000,
+                             departure: "2025.12.12",
+                             homecoming: "2025.12.21")
+            ]
+        )
+    ]
+    
+    ///
+    func transform(input: Input) -> Output {
+        // CoreDataValue의 상태를 기반으로 섹션 업데이트
+           let updatedData = coreDataValue
+               .map { currentSections -> [SectionOfListCellData] in
+                   if currentSections.contains(where: { $0.state == .existState }) {
+                       // 데이터 섹션이 존재하면 빈 섹션 제거
+                       return currentSections.filter { $0.state == .existState }
+                   } else {
+                       // 데이터 섹션이 없으면 빈 섹션만 반환
+                       return [
+                           SectionOfListCellData(
+                               state: .emptyState,
+                               items: [ListCellData(tripName: "", note: "", buget: 0, departure: "", homecoming: "")]
+                           )
+                       ]
+                   }
+               }
+        /// 가장 최근의 데이터를 결합해 방출(최신상태를 가져옴)
+        /// -> 최근 데이터를 임시의 coreData에 저장
+        /// 최신값이 
+        input.buttonTapped
+            .withLatestFrom(coreDataValue)
+            .flatMap { [weak self] currentData -> Observable<[SectionOfListCellData]> in
+                guard let self = self else { return .just(currentData) }
+                
+                guard self.currentIndex < self.dummyData.count else { return .just(currentData) }
+                
+                var updatedData = currentData
+                updatedData.append(self.dummyData[self.currentIndex])
+                self.currentIndex += 1
+                
+                return .just(updatedData)
+            }
+            .bind(to: coreDataValue)
+            .disposed(by: disposeBag)
+        
+        return Output(
+           updatedData: coreDataValue.asDriver(onErrorJustReturn: [])
+        )
+    }
+    
+}


### PR DESCRIPTION
이슈 번호: 
#5  #12 
## 요약
가계부 리스트에 쓰이는 화면을 구현했습니다.

## 작업 상세 내용
- 가계부 리스트에 쓰이는 Cell을 구현했습니다.
- 가계부 리스트 화면 구현했습니다.
- 모달과 연결했습니다.
- 임시 버튼을 통해 cell이 생성되는 동작을 구현했습니다.
- RxCollectionViewSectionedAnimatedDataSource를 활용한 CollectionView를 구현했으며, 애니메이션을 추가해 자연스럽게 구현했습니다.
- alpha값을 활용한 View의 애니메이션 동작을 추가했습니다.

## 리뷰어 공유사항
- 현재 코어데이터와 연결이 되어있지 않아 임시의 더미데이터를 사용하고 있습니다.
- 임시 동작을 위한 코드가 존재하며, 추후에 변경될 예정입니다.
- 변경될 점이 있다면, @jeff-0324 에게 말씀해주세요.

## 스크린샷(선택)
![1:24](https://github.com/user-attachments/assets/730caec4-3e78-4901-a16a-d9615bbd9bc0)

