### PR TITLE
[Feat] FSCalendar 기본 UI 및 커스텀 헤더 구현

### DIFF
--- a/TripLog/TripLog/Feat-Jamong/ModalViewController/View/CalendarCustomHeaderView.swift
+++ b/TripLog/TripLog/Feat-Jamong/ModalViewController/View/CalendarCustomHeaderView.swift
@@ -1,0 +1,123 @@
+//
+//  CalendarCustomHeaderView.swift
+//  TripLog
+//
+//  Created by Jamong on 1/26/25.
+//
+
+import UIKit
+import FSCalendar
+import Then
+import SnapKit
+
+class CalendarCustomHeaderView: UIView {
+    // MARK: - UI Components
+    let titleLabel = UILabel()
+    let previousButton = UIButton(type: .system)
+    let nextButton = UIButton(type: .system)
+    
+    // MARK: - Properties
+    weak var calendar: FSCalendar?
+    
+    // MARK: - Initalization
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setupUI()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    // MARK: - UI Setup
+    private func setupUI() {
+        // 서브뷰 추가
+        [previousButton, titleLabel, nextButton].forEach { addSubview($0) }
+        
+        // 다크모드 UI+Extension Color 설정 필요함.
+        
+        // 이전 달 버튼 설정
+        previousButton.do {
+            $0.setImage(UIImage(systemName: "chevron.left"), for: .normal)
+            $0.tintColor = .black
+            $0.addTarget(self, action: #selector(handlePreviousMonth), for: .touchUpInside)
+        }
+        
+        // 다음 달 버튼 설정
+        nextButton.do {
+            $0.setImage(UIImage(systemName: "chevron.right"), for: .normal)
+            $0.tintColor = .black
+            $0.addTarget(self, action: #selector(handleNextMonth), for: .touchUpInside)
+        }
+        
+        // 날짜 라벨 설정
+        titleLabel.do {
+            $0.font = .SCDream(size: .display, weight: .bold)
+            $0.textColor = .black
+            $0.textAlignment = .center
+        }
+        
+        setupConstraints()
+    }
+    
+    // MARK: - Constraints Setup
+    private func setupConstraints() {
+        // 뷰 자체 높이 설정
+        snp.makeConstraints {
+            $0.height.equalTo(100)
+        }
+        
+        // 이전 달 버튼 제약 조건
+        previousButton.snp.makeConstraints {
+            $0.left.centerY.equalToSuperview()
+            $0.width.equalTo(40)
+        }
+        
+        // 날짜 라벨 제약 조건
+        titleLabel.snp.makeConstraints {
+            $0.center.equalToSuperview()
+        }
+        
+        // 다음 달 버튼 제약 조건
+        nextButton.snp.makeConstraints {
+            $0.right.centerY.equalToSuperview()
+            $0.width.equalTo(40)
+        }
+    }
+    
+    /// 현재 표시된 달의 제목을 업데이트한다.
+    /// - Parameter date: 표시할 날짜
+    func updateTitle(date: Date) {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyy년 M월"
+        titleLabel.text = formatter.string(from: date)
+    }
+    
+    /// 이전 달로 이동하는 버튼 액션을 처리한다.
+    @objc func handlePreviousMonth() {
+        print("클릭")
+        calendar?.setCurrentPage(getPreviousMonth(date: calendar?.currentPage ?? Date()), animated: true)
+        updateTitle(date: calendar?.currentPage ?? Date())
+    }
+    
+    /// 다음 달로 이동하는 버튼 액션을 처리한다.
+    @objc func handleNextMonth() {
+        print("클릭")
+        calendar?.setCurrentPage(getNextMonth(date: calendar?.currentPage ?? Date()), animated: true)
+        updateTitle(date: calendar?.currentPage ?? Date())
+    }
+    
+    /// 주어진 날짜의 이전 달을 반환한다.
+    /// - Parameter date: 기준 날짜
+    /// - Returns: 이전 달의 날짜
+    private func getPreviousMonth(date: Date) -> Date {
+        return Calendar.current.date(byAdding: .month, value: -1, to: date) ?? date
+    }
+    
+    /// 주어진 날짜의 다음 달을 반환한다.
+    /// - Parameter date: 기준 날짜
+    /// - Returns: 다음 달의 날짜
+    private func getNextMonth(date: Date) -> Date {
+        return Calendar.current.date(byAdding: .month, value: 1, to: date) ?? date
+    }
+}

--- a/TripLog/TripLog/Feat-Jamong/ModalViewController/View/CalendarView.swift
+++ b/TripLog/TripLog/Feat-Jamong/ModalViewController/View/CalendarView.swift
@@ -1,0 +1,79 @@
+//
+//  CalendarView.swift
+//  TripLog
+//
+//  Created by Jamong on 1/23/25.
+//
+
+
+import UIKit
+import FSCalendar
+import SnapKit
+import Then
+
+final class CalendarView: UIView {
+    // MARK: - Properties
+    weak var delegate: FSCalendarDelegate? {
+        didSet {
+            calendar.delegate = delegate
+        }
+    }
+    
+    private lazy var calendar = FSCalendar().then {
+        // 스크롤 방향 설정
+        $0.scrollDirection = .horizontal
+        
+        // 캘린더 스코프 설정 -> month: 월간, week: 주간
+        $0.scope = .month
+        
+        $0.appearance.do {
+            // 헤더(년월) 포맷 및 스타일 설정
+            $0.headerDateFormat = "YYYY년 MM월"
+            $0.headerTitleColor = .black
+            $0.headerTitleFont = .boldSystemFont(ofSize: 16)
+            $0.headerMinimumDissolvedAlpha = 0.0
+            
+            // 요일 레이블 스타일 설정
+            $0.weekdayFont = .systemFont(ofSize: 14)
+            $0.weekdayTextColor = .gray
+            
+            // 날짜 셀 스타일 설정
+            $0.titleFont = .systemFont(ofSize: 14)
+            $0.titleDefaultColor = .black
+            $0.titleSelectionColor = .white
+            
+            $0.subtitleFont = .systemFont(ofSize: 10)
+            $0.subtitleDefaultColor = .systemGray
+            
+            $0.subtitleOffset = CGPoint(x: 0, y: 2)
+            
+            $0.selectionColor = .systemBlue
+            $0.todayColor = .systemGray4
+            
+            // 이벤트 표시 스타일 설정
+            $0.eventDefaultColor = .systemBlue
+            $0.eventSelectionColor = .white
+        }
+    }
+    
+    // MARK: - Initialization
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setupUI()
+    }
+    
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        setupUI()
+    }
+    
+    // MARK: - UI Setup
+    private func setupUI() {
+        backgroundColor = .white
+        addSubview(calendar)
+        
+        calendar.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+        }
+    }
+}

--- a/TripLog/TripLog/Feat-Jamong/ModalViewController/View/CalendarView.swift
+++ b/TripLog/TripLog/Feat-Jamong/ModalViewController/View/CalendarView.swift
@@ -8,68 +8,29 @@
 
 import UIKit
 import FSCalendar
-import SnapKit
 import Then
+import SnapKit
 
-final class CalendarView: UIView {
+
+final class CalendarView: UIView, FSCalendarDelegate, FSCalendarDataSource {
     // MARK: - Properties
-    weak var delegate: FSCalendarDelegate? {
-        didSet {
-            calendar.delegate = delegate
-        }
-    }
-    
-    private lazy var calendar = FSCalendar().then {
-        // 스크롤 방향 설정
-        $0.scrollDirection = .horizontal
-        
-        // 캘린더 스코프 설정 -> month: 월간, week: 주간
-        $0.scope = .month
-        
-        $0.appearance.do {
-            // 헤더(년월) 포맷 및 스타일 설정
-            $0.headerDateFormat = "YYYY년 MM월"
-            $0.headerTitleColor = .black
-            $0.headerTitleFont = .boldSystemFont(ofSize: 16)
-            $0.headerMinimumDissolvedAlpha = 0.0
-            
-            // 요일 레이블 스타일 설정
-            $0.weekdayFont = .systemFont(ofSize: 14)
-            $0.weekdayTextColor = .gray
-            
-            // 날짜 셀 스타일 설정
-            $0.titleFont = .systemFont(ofSize: 14)
-            $0.titleDefaultColor = .black
-            $0.titleSelectionColor = .white
-            
-            $0.subtitleFont = .systemFont(ofSize: 10)
-            $0.subtitleDefaultColor = .systemGray
-            
-            $0.subtitleOffset = CGPoint(x: 0, y: 2)
-            
-            $0.selectionColor = .systemBlue
-            $0.todayColor = .systemGray4
-            
-            // 이벤트 표시 스타일 설정
-            $0.eventDefaultColor = .systemBlue
-            $0.eventSelectionColor = .white
-        }
+    lazy var calendar = FSCalendar().then {
+        $0.delegate = self
+        $0.dataSource = self
     }
     
     // MARK: - Initialization
     override init(frame: CGRect) {
         super.init(frame: frame)
-        setupUI()
     }
     
     required init?(coder: NSCoder) {
-        super.init(coder: coder)
-        setupUI()
+        fatalError("init(coder:) has not been implemented")
     }
     
     // MARK: - UI Setup
     private func setupUI() {
-        backgroundColor = .white
+        backgroundColor = .white    // UI+Extension Color로 설정 필요함.
         addSubview(calendar)
         
         calendar.snp.makeConstraints {

--- a/TripLog/TripLog/Feat-Jamong/ModalViewController/View/CalendarView.swift
+++ b/TripLog/TripLog/Feat-Jamong/ModalViewController/View/CalendarView.swift
@@ -15,13 +15,37 @@ import SnapKit
 final class CalendarView: UIView, FSCalendarDelegate, FSCalendarDataSource {
     // MARK: - Properties
     lazy var calendar = FSCalendar().then {
+        // Delegate, DataSource 설정
         $0.delegate = self
         $0.dataSource = self
+
+        // MARK: - CalendarView Set UI
+        $0.appearance.do {
+            // 다크모드 UI+Extension Color 설정 필요함.
+            $0.weekdayFont = .SCDream(size: .display, weight: .medium)
+            $0.titleFont = .SCDream(size: .body, weight: .medium)
+            $0.weekdayTextColor = .black
+            $0.titleDefaultColor = .black
+            $0.selectionColor = .systemBlue
+            $0.todayColor = .gray
+            $0.todaySelectionColor = .systemBlue
+            $0.caseOptions = .weekdayUsesSingleUpperCase
+        }
+        
+        // 기본 헤더 제거
+        $0.headerHeight = 0
+        $0.appearance.headerMinimumDissolvedAlpha = 0
+        
+        // 한국어 및 이전, 이후 달 일자 보이기
+        $0.locale = Locale(identifier: "ko_KR")
+        $0.placeholderType = .fillHeadTail
     }
+
     
     // MARK: - Initialization
     override init(frame: CGRect) {
         super.init(frame: frame)
+        setupUI()
     }
     
     required init?(coder: NSCoder) {
@@ -30,9 +54,10 @@ final class CalendarView: UIView, FSCalendarDelegate, FSCalendarDataSource {
     
     // MARK: - UI Setup
     private func setupUI() {
-        backgroundColor = .white    // UI+Extension Color로 설정 필요함.
+        // UI+Extension Color로 설정 필요함.
+        backgroundColor = .white
         addSubview(calendar)
-        
+
         calendar.snp.makeConstraints {
             $0.edges.equalToSuperview()
         }

--- a/TripLog/TripLog/Feat-Jamong/ModalViewController/View/CalendarViewController.swift
+++ b/TripLog/TripLog/Feat-Jamong/ModalViewController/View/CalendarViewController.swift
@@ -14,22 +14,30 @@ import FSCalendar
 final class CalendarViewController: UIViewController {
     
     // MARK: - Properties
-    private lazy var calendarView = CalendarView()
+    // 캘린더 뷰
+    private lazy var calendarView = CalendarView().then {
+        $0.calendar.delegate = self
+        $0.calendar.dataSource = self
+    }
+    // 커스텀 헤더 뷰
+    private lazy var customHeaderView = CalendarCustomHeaderView(frame: .zero).then {
+        $0.calendar = calendarView.calendar
+    }
+    
     private let disposeBag = DisposeBag()
     
-    // 지출 금액 표시 레이블
-    private lazy var expenseLabel = UILabel().then {
-        $0.textAlignment = .center
-        $0.font = .systemFont(ofSize: 16)
-        $0.textColor = .black
-        $0.text = "총 지출: ₩0" // Default text
-    }
     
     // MARK: - View Lifecycle
     override func viewDidLoad() {
         super.viewDidLoad()
         setupUI()
-        setupCalendarDelegate()
+        setupCalendar()
+    }
+    
+    // 하위 뷰 레이아웃 업데이트 된 후 호출
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+        calendarView.calendar.reloadData()
     }
     
     // MARK: - Setup
@@ -37,34 +45,38 @@ final class CalendarViewController: UIViewController {
         view.backgroundColor = .white
         
         // 서브뷰 추가
-        [calendarView, expenseLabel].forEach { view.addSubview($0) }
+        [customHeaderView, calendarView].forEach { view.addSubview($0) }
         
-        // SnapKit을 사용한 레이아웃 설정
-        calendarView.snp.makeConstraints {
+        customHeaderView.snp.makeConstraints {
             $0.top.equalTo(view.safeAreaLayoutGuide)
             $0.leading.trailing.equalToSuperview()
-            $0.height.equalTo(400)
+            $0.height.equalTo(100)
         }
         
-        expenseLabel.snp.makeConstraints {
-            $0.top.equalTo(calendarView.snp.bottom).offset(20)
-            $0.leading.trailing.equalToSuperview().inset(20)
-            $0.height.equalTo(30)
+        calendarView.snp.makeConstraints {
+            $0.top.equalTo(customHeaderView.snp.bottom)
+            $0.leading.trailing.bottom.equalToSuperview()
         }
     }
     
-    private func setupCalendarDelegate() {
-        calendarView.delegate = self
+    // 캘린더 헤더 타이틀 설정
+    private func setupCalendar() {
+        customHeaderView.updateTitle(date: calendarView.calendar.currentPage)
+    }
+    
+    // MARK: - Public Methods
+    /// 캘린더의 현재 페이지를 지정된 날짜로 변경
+    /// - Parameter date: 이동할 날짜
+    func changeMonth(to date: Date) {
+        calendarView.calendar.setCurrentPage(date, animated: true)
     }
 }
 
 // MARK: - FSCalendarDelegate Extension
 extension CalendarViewController: FSCalendarDelegate, FSCalendarDataSource {
-    func calendar(_ calendar: FSCalendar, didSelect date: Date, at monthPosition: FSCalendarMonthPosition) {
-        let randomExpense = Int.random(in: 1000...100000)
-        expenseLabel.text = "선택한 날짜 지출: ₩\(randomExpense)"
-    }
-    
+    /// 캘린더의 현재 페이지가 변경되었을 때 호출
+    /// - Parameter calendar: 변경된 캘린더 객체
     func calendarCurrentPageDidChange(_ calendar: FSCalendar) {
+        customHeaderView.updateTitle(date: calendar.currentPage)
     }
 }

--- a/TripLog/TripLog/Feat-Jamong/ModalViewController/View/CalendarViewController.swift
+++ b/TripLog/TripLog/Feat-Jamong/ModalViewController/View/CalendarViewController.swift
@@ -1,0 +1,70 @@
+//
+//  CalendarViewController.swift
+//  TripLog
+//
+//  Created by Jamong on 1/23/25.
+//
+
+import UIKit
+import RxSwift
+import Then
+import SnapKit
+import FSCalendar
+
+final class CalendarViewController: UIViewController {
+    
+    // MARK: - Properties
+    private lazy var calendarView = CalendarView()
+    private let disposeBag = DisposeBag()
+    
+    // 지출 금액 표시 레이블
+    private lazy var expenseLabel = UILabel().then {
+        $0.textAlignment = .center
+        $0.font = .systemFont(ofSize: 16)
+        $0.textColor = .black
+        $0.text = "총 지출: ₩0" // Default text
+    }
+    
+    // MARK: - View Lifecycle
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        setupUI()
+        setupCalendarDelegate()
+    }
+    
+    // MARK: - Setup
+    private func setupUI() {
+        view.backgroundColor = .white
+        
+        // 서브뷰 추가
+        [calendarView, expenseLabel].forEach { view.addSubview($0) }
+        
+        // SnapKit을 사용한 레이아웃 설정
+        calendarView.snp.makeConstraints {
+            $0.top.equalTo(view.safeAreaLayoutGuide)
+            $0.leading.trailing.equalToSuperview()
+            $0.height.equalTo(400)
+        }
+        
+        expenseLabel.snp.makeConstraints {
+            $0.top.equalTo(calendarView.snp.bottom).offset(20)
+            $0.leading.trailing.equalToSuperview().inset(20)
+            $0.height.equalTo(30)
+        }
+    }
+    
+    private func setupCalendarDelegate() {
+        calendarView.delegate = self
+    }
+}
+
+// MARK: - FSCalendarDelegate Extension
+extension CalendarViewController: FSCalendarDelegate, FSCalendarDataSource {
+    func calendar(_ calendar: FSCalendar, didSelect date: Date, at monthPosition: FSCalendarMonthPosition) {
+        let randomExpense = Int.random(in: 1000...100000)
+        expenseLabel.text = "선택한 날짜 지출: ₩\(randomExpense)"
+    }
+    
+    func calendarCurrentPageDidChange(_ calendar: FSCalendar) {
+    }
+}


### PR DESCRIPTION
이슈 번호: #23 

## 요약
FSCalendar 라이브러리를 사용하여 캘린더 기본 UI와 커스텀 헤더를 구현했습니다.
**(UI Extension Style 적용은 UI가 완료되면 적용할 예정입니다.)**

## 작업 상세 내용
- CalendarViewController 생성
- CalendarView 구현
- CalendarCustomHeaderView 구현
- 캘린더 기본 스타일링 
- 월 이동 및 타이틀 업데이트 기능 구현

## 리뷰어 공유사항
- 폰트, 색상 등 기본 스타일은 임시로 설정되었으며 추후 디자인 시안에 맞게 조정 필요 (다크모드 대응)
- 기본적인 월 이동 및 캘린더 UI 기능 구현 완료
- CalendarViewModel 및 CalendarHeaderViewModel은 CustomCell 완료 후 구현 예정입니다 (리팩토링)

## 스크린샷
![Simulator Screenshot - iPhone 16 - 2025-01-27 at 20 38 40](https://github.com/user-attachments/assets/24dde28e-8cb8-43c0-93aa-602ea5c2976b)
