### PR TITLE
[Feat] 캘린더 커스텀 셀 UI 기본 구조 구현

### DIFF
--- a/TripLog/TripLog/Feat-Jamong/ModalViewController/View/CalendarCustomCell.swift
+++ b/TripLog/TripLog/Feat-Jamong/ModalViewController/View/CalendarCustomCell.swift
@@ -1,0 +1,64 @@
+//
+//  CalendarCustomCell.swift
+//  TripLog
+//
+//  Created by Jamong on 1/28/25.
+//
+
+import UIKit
+import FSCalendar
+import Then
+import SnapKit
+
+class CalendarCustomCell: FSCalendarCell {
+    // MARK: - UI Components
+    
+    /// 일자 라벨
+    public let dateLabel = UILabel().then {
+        $0.font = .SCDream(size: .caption, weight: .medium)
+        $0.textAlignment = .center
+    }
+    
+    /// 해당 일자 지출 금액 라벨
+    public let expenseLabel = UILabel().then {
+        $0.font = .SCDream(size: .subcaption, weight: .medium)
+        $0.textAlignment = .center
+        $0.textColor = .red
+    }
+    
+    // MARK: - Initialization
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setupUI()
+    }
+    
+    required init?(coder aDecoder: NSCoder) {
+        super.init(coder: aDecoder)
+        setupUI()
+    }
+    
+    // MARK: - UI Setup
+    private func setupUI() {
+        contentView.addSubview(dateLabel)
+        contentView.addSubview(expenseLabel)
+        
+        dateLabel.snp.makeConstraints {
+            $0.centerX.equalToSuperview()
+            $0.centerY.equalToSuperview()
+        }
+        
+        expenseLabel.snp.makeConstraints {
+            $0.top.equalTo(dateLabel.snp.bottom).offset(2)
+            $0.centerX.equalToSuperview()
+        }
+    }
+    
+    // MARK: - Cell Reuse Preparation
+    /// 셀 재사용시 라벨 초기화
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        dateLabel.text = nil
+        expenseLabel.text = nil
+    }
+}
+

--- a/TripLog/TripLog/Feat-Jamong/ModalViewController/View/CalendarCustomHeaderView.swift
+++ b/TripLog/TripLog/Feat-Jamong/ModalViewController/View/CalendarCustomHeaderView.swift
@@ -1,0 +1,123 @@
+//
+//  CalendarCustomHeaderView.swift
+//  TripLog
+//
+//  Created by Jamong on 1/26/25.
+//
+
+import UIKit
+import FSCalendar
+import Then
+import SnapKit
+
+class CalendarCustomHeaderView: UIView {
+    // MARK: - UI Components
+    let titleLabel = UILabel()
+    let previousButton = UIButton(type: .system)
+    let nextButton = UIButton(type: .system)
+    
+    // MARK: - Properties
+    weak var calendar: FSCalendar?
+    
+    // MARK: - Initalization
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setupUI()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    // MARK: - UI Setup
+    private func setupUI() {
+        // 서브뷰 추가
+        [previousButton, titleLabel, nextButton].forEach { addSubview($0) }
+        
+        // 다크모드 UI+Extension Color 설정 필요함.
+        
+        // 이전 달 버튼 설정
+        previousButton.do {
+            $0.setImage(UIImage(systemName: "chevron.left"), for: .normal)
+            $0.tintColor = .black
+            $0.addTarget(self, action: #selector(handlePreviousMonth), for: .touchUpInside)
+        }
+        
+        // 다음 달 버튼 설정
+        nextButton.do {
+            $0.setImage(UIImage(systemName: "chevron.right"), for: .normal)
+            $0.tintColor = .black
+            $0.addTarget(self, action: #selector(handleNextMonth), for: .touchUpInside)
+        }
+        
+        // 날짜 라벨 설정
+        titleLabel.do {
+            $0.font = .SCDream(size: .display, weight: .bold)
+            $0.textColor = .black
+            $0.textAlignment = .center
+        }
+        
+        setupConstraints()
+    }
+    
+    // MARK: - Constraints Setup
+    private func setupConstraints() {
+        // 뷰 자체 높이 설정
+        snp.makeConstraints {
+            $0.height.equalTo(100)
+        }
+        
+        // 이전 달 버튼 제약 조건
+        previousButton.snp.makeConstraints {
+            $0.left.centerY.equalToSuperview()
+            $0.width.equalTo(40)
+        }
+        
+        // 날짜 라벨 제약 조건
+        titleLabel.snp.makeConstraints {
+            $0.center.equalToSuperview()
+        }
+        
+        // 다음 달 버튼 제약 조건
+        nextButton.snp.makeConstraints {
+            $0.right.centerY.equalToSuperview()
+            $0.width.equalTo(40)
+        }
+    }
+    
+    /// 현재 표시된 달의 제목을 업데이트한다.
+    /// - Parameter date: 표시할 날짜
+    func updateTitle(date: Date) {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyy년 M월"
+        titleLabel.text = formatter.string(from: date)
+    }
+    
+    /// 이전 달로 이동하는 버튼 액션을 처리한다.
+    @objc func handlePreviousMonth() {
+        print("클릭")
+        calendar?.setCurrentPage(getPreviousMonth(date: calendar?.currentPage ?? Date()), animated: true)
+        updateTitle(date: calendar?.currentPage ?? Date())
+    }
+    
+    /// 다음 달로 이동하는 버튼 액션을 처리한다.
+    @objc func handleNextMonth() {
+        print("클릭")
+        calendar?.setCurrentPage(getNextMonth(date: calendar?.currentPage ?? Date()), animated: true)
+        updateTitle(date: calendar?.currentPage ?? Date())
+    }
+    
+    /// 주어진 날짜의 이전 달을 반환한다.
+    /// - Parameter date: 기준 날짜
+    /// - Returns: 이전 달의 날짜
+    private func getPreviousMonth(date: Date) -> Date {
+        return Calendar.current.date(byAdding: .month, value: -1, to: date) ?? date
+    }
+    
+    /// 주어진 날짜의 다음 달을 반환한다.
+    /// - Parameter date: 기준 날짜
+    /// - Returns: 다음 달의 날짜
+    private func getNextMonth(date: Date) -> Date {
+        return Calendar.current.date(byAdding: .month, value: 1, to: date) ?? date
+    }
+}

--- a/TripLog/TripLog/Feat-Jamong/ModalViewController/View/CalendarView.swift
+++ b/TripLog/TripLog/Feat-Jamong/ModalViewController/View/CalendarView.swift
@@ -1,0 +1,79 @@
+//
+//  CalendarView.swift
+//  TripLog
+//
+//  Created by Jamong on 1/23/25.
+//
+
+
+import UIKit
+import FSCalendar
+import SnapKit
+import Then
+
+final class CalendarView: UIView {
+    // MARK: - Properties
+    weak var delegate: FSCalendarDelegate? {
+        didSet {
+            calendar.delegate = delegate
+        }
+    }
+    
+    private lazy var calendar = FSCalendar().then {
+        // 스크롤 방향 설정
+        $0.scrollDirection = .horizontal
+        
+        // 캘린더 스코프 설정 -> month: 월간, week: 주간
+        $0.scope = .month
+        
+        $0.appearance.do {
+            // 헤더(년월) 포맷 및 스타일 설정
+            $0.headerDateFormat = "YYYY년 MM월"
+            $0.headerTitleColor = .black
+            $0.headerTitleFont = .boldSystemFont(ofSize: 16)
+            $0.headerMinimumDissolvedAlpha = 0.0
+            
+            // 요일 레이블 스타일 설정
+            $0.weekdayFont = .systemFont(ofSize: 14)
+            $0.weekdayTextColor = .gray
+            
+            // 날짜 셀 스타일 설정
+            $0.titleFont = .systemFont(ofSize: 14)
+            $0.titleDefaultColor = .black
+            $0.titleSelectionColor = .white
+            
+            $0.subtitleFont = .systemFont(ofSize: 10)
+            $0.subtitleDefaultColor = .systemGray
+            
+            $0.subtitleOffset = CGPoint(x: 0, y: 2)
+            
+            $0.selectionColor = .systemBlue
+            $0.todayColor = .systemGray4
+            
+            // 이벤트 표시 스타일 설정
+            $0.eventDefaultColor = .systemBlue
+            $0.eventSelectionColor = .white
+        }
+    }
+    
+    // MARK: - Initialization
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setupUI()
+    }
+    
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        setupUI()
+    }
+    
+    // MARK: - UI Setup
+    private func setupUI() {
+        backgroundColor = .white
+        addSubview(calendar)
+        
+        calendar.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+        }
+    }
+}

--- a/TripLog/TripLog/Feat-Jamong/ModalViewController/View/CalendarView.swift
+++ b/TripLog/TripLog/Feat-Jamong/ModalViewController/View/CalendarView.swift
@@ -8,68 +8,29 @@
 
 import UIKit
 import FSCalendar
-import SnapKit
 import Then
+import SnapKit
 
-final class CalendarView: UIView {
+
+final class CalendarView: UIView, FSCalendarDelegate, FSCalendarDataSource {
     // MARK: - Properties
-    weak var delegate: FSCalendarDelegate? {
-        didSet {
-            calendar.delegate = delegate
-        }
-    }
-    
-    private lazy var calendar = FSCalendar().then {
-        // 스크롤 방향 설정
-        $0.scrollDirection = .horizontal
-        
-        // 캘린더 스코프 설정 -> month: 월간, week: 주간
-        $0.scope = .month
-        
-        $0.appearance.do {
-            // 헤더(년월) 포맷 및 스타일 설정
-            $0.headerDateFormat = "YYYY년 MM월"
-            $0.headerTitleColor = .black
-            $0.headerTitleFont = .boldSystemFont(ofSize: 16)
-            $0.headerMinimumDissolvedAlpha = 0.0
-            
-            // 요일 레이블 스타일 설정
-            $0.weekdayFont = .systemFont(ofSize: 14)
-            $0.weekdayTextColor = .gray
-            
-            // 날짜 셀 스타일 설정
-            $0.titleFont = .systemFont(ofSize: 14)
-            $0.titleDefaultColor = .black
-            $0.titleSelectionColor = .white
-            
-            $0.subtitleFont = .systemFont(ofSize: 10)
-            $0.subtitleDefaultColor = .systemGray
-            
-            $0.subtitleOffset = CGPoint(x: 0, y: 2)
-            
-            $0.selectionColor = .systemBlue
-            $0.todayColor = .systemGray4
-            
-            // 이벤트 표시 스타일 설정
-            $0.eventDefaultColor = .systemBlue
-            $0.eventSelectionColor = .white
-        }
+    lazy var calendar = FSCalendar().then {
+        $0.delegate = self
+        $0.dataSource = self
     }
     
     // MARK: - Initialization
     override init(frame: CGRect) {
         super.init(frame: frame)
-        setupUI()
     }
     
     required init?(coder: NSCoder) {
-        super.init(coder: coder)
-        setupUI()
+        fatalError("init(coder:) has not been implemented")
     }
     
     // MARK: - UI Setup
     private func setupUI() {
-        backgroundColor = .white
+        backgroundColor = .white    // UI+Extension Color로 설정 필요함.
         addSubview(calendar)
         
         calendar.snp.makeConstraints {

--- a/TripLog/TripLog/Feat-Jamong/ModalViewController/View/CalendarView.swift
+++ b/TripLog/TripLog/Feat-Jamong/ModalViewController/View/CalendarView.swift
@@ -15,13 +15,37 @@ import SnapKit
 final class CalendarView: UIView, FSCalendarDelegate, FSCalendarDataSource {
     // MARK: - Properties
     lazy var calendar = FSCalendar().then {
+        // Delegate, DataSource 설정
         $0.delegate = self
         $0.dataSource = self
+
+        // MARK: - CalendarView Set UI
+        $0.appearance.do {
+            // 다크모드 UI+Extension Color 설정 필요함.
+            $0.weekdayFont = .SCDream(size: .display, weight: .medium)
+            $0.titleFont = .SCDream(size: .body, weight: .medium)
+            $0.weekdayTextColor = .black
+            $0.titleDefaultColor = .black
+            $0.selectionColor = .systemBlue
+            $0.todayColor = .gray
+            $0.todaySelectionColor = .systemBlue
+            $0.caseOptions = .weekdayUsesSingleUpperCase
+        }
+        
+        // 기본 헤더 제거
+        $0.headerHeight = 0
+        $0.appearance.headerMinimumDissolvedAlpha = 0
+        
+        // 한국어 및 이전, 이후 달 일자 보이기
+        $0.locale = Locale(identifier: "ko_KR")
+        $0.placeholderType = .fillHeadTail
     }
+
     
     // MARK: - Initialization
     override init(frame: CGRect) {
         super.init(frame: frame)
+        setupUI()
     }
     
     required init?(coder: NSCoder) {
@@ -30,9 +54,10 @@ final class CalendarView: UIView, FSCalendarDelegate, FSCalendarDataSource {
     
     // MARK: - UI Setup
     private func setupUI() {
-        backgroundColor = .white    // UI+Extension Color로 설정 필요함.
+        // UI+Extension Color로 설정 필요함.
+        backgroundColor = .white
         addSubview(calendar)
-        
+
         calendar.snp.makeConstraints {
             $0.edges.equalToSuperview()
         }

--- a/TripLog/TripLog/Feat-Jamong/ModalViewController/View/CalendarView.swift
+++ b/TripLog/TripLog/Feat-Jamong/ModalViewController/View/CalendarView.swift
@@ -18,6 +18,9 @@ final class CalendarView: UIView, FSCalendarDelegate, FSCalendarDataSource {
         // Delegate, DataSource 설정
         $0.delegate = self
         $0.dataSource = self
+        
+        $0.allowsMultipleSelection = false
+
 
         // MARK: - CalendarView Set UI
         $0.appearance.do {
@@ -26,9 +29,10 @@ final class CalendarView: UIView, FSCalendarDelegate, FSCalendarDataSource {
             $0.titleFont = .SCDream(size: .body, weight: .medium)
             $0.weekdayTextColor = .black
             $0.titleDefaultColor = .black
-            $0.selectionColor = .systemBlue
-            $0.todayColor = .gray
-            $0.todaySelectionColor = .systemBlue
+            $0.selectionColor = .clear
+            $0.todayColor = .clear
+            
+            $0.todaySelectionColor = .clear
             $0.caseOptions = .weekdayUsesSingleUpperCase
         }
         

--- a/TripLog/TripLog/Feat-Jamong/ModalViewController/View/CalendarViewController.swift
+++ b/TripLog/TripLog/Feat-Jamong/ModalViewController/View/CalendarViewController.swift
@@ -14,22 +14,30 @@ import FSCalendar
 final class CalendarViewController: UIViewController {
     
     // MARK: - Properties
-    private lazy var calendarView = CalendarView()
+    // 캘린더 뷰
+    private lazy var calendarView = CalendarView().then {
+        $0.calendar.delegate = self
+        $0.calendar.dataSource = self
+    }
+    // 커스텀 헤더 뷰
+    private lazy var customHeaderView = CalendarCustomHeaderView(frame: .zero).then {
+        $0.calendar = calendarView.calendar
+    }
+    
     private let disposeBag = DisposeBag()
     
-    // 지출 금액 표시 레이블
-    private lazy var expenseLabel = UILabel().then {
-        $0.textAlignment = .center
-        $0.font = .systemFont(ofSize: 16)
-        $0.textColor = .black
-        $0.text = "총 지출: ₩0" // Default text
-    }
     
     // MARK: - View Lifecycle
     override func viewDidLoad() {
         super.viewDidLoad()
         setupUI()
-        setupCalendarDelegate()
+        setupCalendar()
+    }
+    
+    // 하위 뷰 레이아웃 업데이트 된 후 호출
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+        calendarView.calendar.reloadData()
     }
     
     // MARK: - Setup
@@ -37,34 +45,38 @@ final class CalendarViewController: UIViewController {
         view.backgroundColor = .white
         
         // 서브뷰 추가
-        [calendarView, expenseLabel].forEach { view.addSubview($0) }
+        [customHeaderView, calendarView].forEach { view.addSubview($0) }
         
-        // SnapKit을 사용한 레이아웃 설정
-        calendarView.snp.makeConstraints {
+        customHeaderView.snp.makeConstraints {
             $0.top.equalTo(view.safeAreaLayoutGuide)
             $0.leading.trailing.equalToSuperview()
-            $0.height.equalTo(400)
+            $0.height.equalTo(100)
         }
         
-        expenseLabel.snp.makeConstraints {
-            $0.top.equalTo(calendarView.snp.bottom).offset(20)
-            $0.leading.trailing.equalToSuperview().inset(20)
-            $0.height.equalTo(30)
+        calendarView.snp.makeConstraints {
+            $0.top.equalTo(customHeaderView.snp.bottom)
+            $0.leading.trailing.bottom.equalToSuperview()
         }
     }
     
-    private func setupCalendarDelegate() {
-        calendarView.delegate = self
+    // 캘린더 헤더 타이틀 설정
+    private func setupCalendar() {
+        customHeaderView.updateTitle(date: calendarView.calendar.currentPage)
+    }
+    
+    // MARK: - Public Methods
+    /// 캘린더의 현재 페이지를 지정된 날짜로 변경
+    /// - Parameter date: 이동할 날짜
+    func changeMonth(to date: Date) {
+        calendarView.calendar.setCurrentPage(date, animated: true)
     }
 }
 
 // MARK: - FSCalendarDelegate Extension
 extension CalendarViewController: FSCalendarDelegate, FSCalendarDataSource {
-    func calendar(_ calendar: FSCalendar, didSelect date: Date, at monthPosition: FSCalendarMonthPosition) {
-        let randomExpense = Int.random(in: 1000...100000)
-        expenseLabel.text = "선택한 날짜 지출: ₩\(randomExpense)"
-    }
-    
+    /// 캘린더의 현재 페이지가 변경되었을 때 호출
+    /// - Parameter calendar: 변경된 캘린더 객체
     func calendarCurrentPageDidChange(_ calendar: FSCalendar) {
+        customHeaderView.updateTitle(date: calendar.currentPage)
     }
 }

--- a/TripLog/TripLog/Feat-Jamong/ModalViewController/View/CalendarViewController.swift
+++ b/TripLog/TripLog/Feat-Jamong/ModalViewController/View/CalendarViewController.swift
@@ -5,6 +5,9 @@
 //  Created by Jamong on 1/23/25.
 //
 
+
+
+// CalendarViewController.swift 수정
 import UIKit
 import RxSwift
 import Then
@@ -12,32 +15,35 @@ import SnapKit
 import FSCalendar
 
 final class CalendarViewController: UIViewController {
-    
     // MARK: - Properties
     // 캘린더 뷰
     private lazy var calendarView = CalendarView().then {
         $0.calendar.delegate = self
         $0.calendar.dataSource = self
+        
+        // 커스텀 셀 등록
+        $0.calendar.register(CalendarCustomCell.self, forCellReuseIdentifier: "CalendarCustomCell")
     }
+    
     // 커스텀 헤더 뷰
     private lazy var customHeaderView = CalendarCustomHeaderView(frame: .zero).then {
         $0.calendar = calendarView.calendar
     }
     
-    private let disposeBag = DisposeBag()
+    // 가짜 데이터 생성
+    private var fakeTripExpenses: [Date: Double] = [:]
     
+    private let disposeBag = DisposeBag()
     
     // MARK: - View Lifecycle
     override func viewDidLoad() {
         super.viewDidLoad()
         setupUI()
         setupCalendar()
-    }
-    
-    // 하위 뷰 레이아웃 업데이트 된 후 호출
-    override func viewDidLayoutSubviews() {
-        super.viewDidLayoutSubviews()
-        calendarView.calendar.reloadData()
+        generateFakeExpenseData()
+        
+        // 오늘 날짜 선택
+        calendarView.calendar.select(Date())
     }
     
     // MARK: - Setup
@@ -64,19 +70,123 @@ final class CalendarViewController: UIViewController {
         customHeaderView.updateTitle(date: calendarView.calendar.currentPage)
     }
     
-    // MARK: - Public Methods
     /// 캘린더의 현재 페이지를 지정된 날짜로 변경
     /// - Parameter date: 이동할 날짜
     func changeMonth(to date: Date) {
         calendarView.calendar.setCurrentPage(date, animated: true)
     }
+
+    
+    // 가짜 지출 데이터 생성
+    private func generateFakeExpenseData() {
+        let calendar = Calendar.current
+        let currentDate = Date()
+        
+        // 현재 월의 1일부터 말일까지 랜덤 지출 데이터 생성
+        var dateComponents = calendar.dateComponents([.year, .month], from: currentDate)
+        
+        for day in 1...31 {
+            dateComponents.day = day
+            
+            if let date = calendar.date(from: dateComponents) {
+                if Bool.random() {
+                    fakeTripExpenses[date] = Double.random(in: 1000...100000)
+                }
+            }
+        }
+    }
 }
 
-// MARK: - FSCalendarDelegate Extension
+// MARK: - FSCalendarDelegate, FSCalendarDataSource
 extension CalendarViewController: FSCalendarDelegate, FSCalendarDataSource {
     /// 캘린더의 현재 페이지가 변경되었을 때 호출
     /// - Parameter calendar: 변경된 캘린더 객체
     func calendarCurrentPageDidChange(_ calendar: FSCalendar) {
         customHeaderView.updateTitle(date: calendar.currentPage)
+    }
+    
+    /// 각 날짜에 대한 캘린더 셀을 생성하고 구성한다.
+    /// - Parameters:
+    ///   - calendar: 현재 FSCalendar 인스턴스
+    ///   - date: 셀에 표시될 날짜
+    ///   - position: 날짜의 월 내 위치 (현재 월, 이전/다음 월 등)
+    /// - Returns: 구성된 FSCalendarCell
+    func calendar(_ calendar: FSCalendar, cellFor date: Date, at position: FSCalendarMonthPosition) -> FSCalendarCell {
+        guard let cell = calendar.dequeueReusableCell(withIdentifier: "CalendarCustomCell", for: date, at: position) as? CalendarCustomCell else {
+            return FSCalendarCell()
+        }
+        
+        // 날짜 구성
+        let day = Calendar.current.component(.day, from: date)
+        cell.titleLabel.text = "\(day)"
+        
+        // 지출 데이터 표시
+        if let expense = fakeTripExpenses[date] {
+            cell.expenseLabel.text = (Int(expense).formatted())
+            cell.expenseLabel.isHidden = false
+        } else {
+            cell.expenseLabel.text = nil
+            cell.expenseLabel.isHidden = true
+        }
+        
+        // 선택된 날짜만 정확히 처리
+        if calendar.selectedDate == date {
+            cell.contentView.backgroundColor = .systemBlue
+            cell.contentView.layer.cornerRadius = 10
+            cell.contentView.layer.masksToBounds = true
+            cell.titleLabel.textColor = .white
+            cell.expenseLabel.textColor = .white
+        } else {
+            let isToday = Calendar.current.isDateInToday(date)
+            
+            if isToday {
+                cell.titleLabel.textColor = .systemBlue
+            } else {
+                cell.titleLabel.textColor = .label
+                cell.expenseLabel.textColor = .red
+            }
+            
+            cell.contentView.layer.cornerRadius = 0
+            cell.contentView.backgroundColor = .clear
+        }
+        
+        return cell
+    }
+    
+    /// 날짜가 선택되었을 때 호출되는 메서드 (데이터 확인용)
+    /// - Parameters:
+    ///   - calendar: 현재 FSCalendar 인스턴스
+    ///   - date: 선택된 날짜
+    ///   - monthPosition: 선택된 날짜의 월 내 위치
+    func calendar(_ calendar: FSCalendar, didSelect date: Date, at monthPosition: FSCalendarMonthPosition) {
+        // 선택된 날짜에 대한 추가 작업 (필요한 경우)
+        let calendars = Calendar.current
+        
+        print("Date: \(date)")
+        print("Month: \(calendars.component(.month, from: date))")
+        print("Day: \(calendars.component(.day, from: date))")
+        
+        // 지출 정보 확인
+        if let expense = fakeTripExpenses[date] {
+            print("지출: ₩\(Int(expense).formatted())")
+        } else {
+            print("데이터 없음")
+        }
+        
+        print("==================================")
+        
+        calendar.reloadData()
+    }
+}
+
+extension CalendarView {
+    func setupCustomCalendar() {
+        calendar.register(CalendarCustomCell.self, forCellReuseIdentifier: "CalendarCustomCell")
+        
+        calendar.appearance.do {
+            // 기존 설정 유지
+            $0.eventDefaultColor = .systemBlue
+            $0.eventSelectionColor = .systemBlue
+        }
     }
 }

--- a/TripLog/TripLog/Feat-Jamong/ModalViewController/View/CalendarViewController.swift
+++ b/TripLog/TripLog/Feat-Jamong/ModalViewController/View/CalendarViewController.swift
@@ -1,0 +1,70 @@
+//
+//  CalendarViewController.swift
+//  TripLog
+//
+//  Created by Jamong on 1/23/25.
+//
+
+import UIKit
+import RxSwift
+import Then
+import SnapKit
+import FSCalendar
+
+final class CalendarViewController: UIViewController {
+    
+    // MARK: - Properties
+    private lazy var calendarView = CalendarView()
+    private let disposeBag = DisposeBag()
+    
+    // 지출 금액 표시 레이블
+    private lazy var expenseLabel = UILabel().then {
+        $0.textAlignment = .center
+        $0.font = .systemFont(ofSize: 16)
+        $0.textColor = .black
+        $0.text = "총 지출: ₩0" // Default text
+    }
+    
+    // MARK: - View Lifecycle
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        setupUI()
+        setupCalendarDelegate()
+    }
+    
+    // MARK: - Setup
+    private func setupUI() {
+        view.backgroundColor = .white
+        
+        // 서브뷰 추가
+        [calendarView, expenseLabel].forEach { view.addSubview($0) }
+        
+        // SnapKit을 사용한 레이아웃 설정
+        calendarView.snp.makeConstraints {
+            $0.top.equalTo(view.safeAreaLayoutGuide)
+            $0.leading.trailing.equalToSuperview()
+            $0.height.equalTo(400)
+        }
+        
+        expenseLabel.snp.makeConstraints {
+            $0.top.equalTo(calendarView.snp.bottom).offset(20)
+            $0.leading.trailing.equalToSuperview().inset(20)
+            $0.height.equalTo(30)
+        }
+    }
+    
+    private func setupCalendarDelegate() {
+        calendarView.delegate = self
+    }
+}
+
+// MARK: - FSCalendarDelegate Extension
+extension CalendarViewController: FSCalendarDelegate, FSCalendarDataSource {
+    func calendar(_ calendar: FSCalendar, didSelect date: Date, at monthPosition: FSCalendarMonthPosition) {
+        let randomExpense = Int.random(in: 1000...100000)
+        expenseLabel.text = "선택한 날짜 지출: ₩\(randomExpense)"
+    }
+    
+    func calendarCurrentPageDidChange(_ calendar: FSCalendar) {
+    }
+}

--- a/TripLog/TripLog/Source/Extension/UIFont+Extension.swift
+++ b/TripLog/TripLog/Source/Extension/UIFont+Extension.swift
@@ -10,6 +10,7 @@ import UIKit
 
 extension UIFont {
     enum FontSize: CGFloat {
+        case subcaption = 6
         case caption = 10
         case body = 12
         case headline = 14


### PR DESCRIPTION
이슈 번호: 
#33 

## 요약
FSCalendar의 커스텀 캘린더 셀을 구현하여 여행 및 지출 정보를 시각적으로 표시할 수 있는 UI를 개발함.

## 작업 상세 내용
- 캘린더 커스텀 셀 클래스 생성 (CalendarCustomCell)
  * 날짜 라벨 구현
  * 지출 금액 라벨 추가
- FSCalendar 델리게이트 메서드 Extension
  * 셀 로직 구현
  * 날짜 선택 이벤트 처리
- 가짜 지출 데이터 생성 로직 추가

## 리뷰어 공유사항
- 커스텀 셀 UI 레이아웃 및 스타일링 -> 다음 작업
- 날짜 선택 이벤트 애니메이션 처리 예정
- 가짜 데이터 생성 로직 -> 삭제 예정
- 델리게이트 메서드 구현 -> VIewModel 생성 후 리팩토리 예정

## 스크린샷(선택)
![Simulator Screen Recording - iPhone 15 Pro - 2025-01-30 at 18 26 33](https://github.com/user-attachments/assets/3c188936-1aed-4292-a3df-0936b0c82849)

- 클릭시 데이터 로그 확인
<img width="696" alt="스크린샷 2025-01-30 오후 6 51 54" src="https://github.com/user-attachments/assets/362e92e6-d507-49f8-a788-c49bc0238081" />

