### PR TITLE
[Feat] 모달뷰 검사 옵션 추가

### DIFF
--- a/TripLog/TripLog/Feat-Crois/ModalViewController/View/ModalAmoutView.swift
+++ b/TripLog/TripLog/Feat-Crois/ModalViewController/View/ModalAmoutView.swift
@@ -8,6 +8,8 @@
 import UIKit
 import SnapKit
 import Then
+import RxSwift
+import RxCocoa
 
 /// 모달뷰에서 금액을 입력하는 공용 컴포넌츠
 final class ModalAmoutView: UIView {
@@ -33,7 +35,7 @@ final class ModalAmoutView: UIView {
         $0.backgroundColor = .clear
     }
     
-    private let textField = UITextField().then {
+    fileprivate let textField = UITextField().then {
         $0.setPlaceholder(title: "0", color: .Light.r400)
         $0.font = UIFont.SCDream(size: .body, weight: .regular)
         $0.textColor = UIColor.Dark.base
@@ -135,4 +137,13 @@ private extension ModalAmoutView {
         }
     }
     
+}
+
+extension Reactive where Base: ModalAmoutView {
+    var isBlank: Observable<Bool> {
+        return base.textField.rx.text.orEmpty
+            .map { $0.isEmpty }
+            .distinctUntilChanged()
+            .asObservable()
+    }
 }

--- a/TripLog/TripLog/Feat-Crois/ModalViewController/View/ModalDatePicker.swift
+++ b/TripLog/TripLog/Feat-Crois/ModalViewController/View/ModalDatePicker.swift
@@ -151,7 +151,8 @@ extension Reactive where Base: ModalDatePicker {
         return base.datePicker.rx.date.asObservable()
     }
     
-    var isBlank: Observable<Bool> {
+    /// DatePicker의 날짜가 선택되었는지 확인하는 옵저버블
+    var datePickerIsBlank: Observable<Bool> {
         return base.textField.rx.text.orEmpty
             .map { $0.count <= 0 }
             .distinctUntilChanged()

--- a/TripLog/TripLog/Feat-Crois/ModalViewController/View/ModalDatePicker.swift
+++ b/TripLog/TripLog/Feat-Crois/ModalViewController/View/ModalDatePicker.swift
@@ -14,6 +14,8 @@ import RxCocoa
 /// 모달뷰에서 날짜를 선택하는 공용 컴포넌츠
 final class ModalDatePicker: UIView {
     
+    private let disposeBag = DisposeBag()
+    
     // MARK: - UI Components
     
     fileprivate let datePicker = UIDatePicker().then {
@@ -22,7 +24,7 @@ final class ModalDatePicker: UIView {
         $0.locale = .init(identifier: "KO_kr")
     }
     
-    private let textField = UITextField().then {
+    fileprivate let textField = UITextField().then {
         $0.setPlaceholder(title: "mm/dd/yyyy", color: .Light.r400)
         $0.font = UIFont.SCDream(size: .body, weight: .regular)
         $0.textColor = UIColor.Dark.base
@@ -36,7 +38,7 @@ final class ModalDatePicker: UIView {
         $0.rightViewMode = .always
         $0.autocapitalizationType = .none
         $0.keyboardType = .default
-        $0.isEnabled = false
+        $0.isUserInteractionEnabled = false
     }
     
     private let calendarView = UIImageView().then {
@@ -57,11 +59,11 @@ final class ModalDatePicker: UIView {
         switch direction {
         case .right:
             textField.layer.maskedCorners = [.layerMaxXMinYCorner
-                                      , .layerMaxXMaxYCorner]
+                                             , .layerMaxXMaxYCorner]
             
         case .left:
             textField.layer.maskedCorners = [.layerMinXMinYCorner
-                                      , .layerMinXMaxYCorner]
+                                             , .layerMinXMaxYCorner]
         }
     }
     
@@ -77,15 +79,10 @@ final class ModalDatePicker: UIView {
         }
     }
     
-    /// DatePicker 뷰의 날짜를 설정하는 메소드
-    /// - Parameter date: 입력할 날짜
-    func configureTextField(date: Date) {
-        let formatter = DateFormatter()
-        formatter.dateFormat = "yyyy년 MM월 dd일"
-        
-        self.textField.text = formatter.string(from: date)
+    func configureDatePicker(date: Date) {
+        datePicker.rx.date.onNext(date)
+        updateTextField(date: date)
     }
-    
 }
 
 // MARK: - UI Setting Method
@@ -95,6 +92,7 @@ private extension ModalDatePicker {
     func setupUI() {
         configureSelf()
         setupLayout()
+        bind()
     }
     
     func configureSelf() {
@@ -118,6 +116,31 @@ private extension ModalDatePicker {
         }
     }
     
+    /// DatePicker 뷰의 날짜를 설정하는 메소드
+    /// - Parameter date: 입력할 날짜
+    func updateTextField(date: Date) {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy년 MM월 dd일"
+        
+        DispatchQueue.main.async { [weak self] in
+            self?.textField.text = formatter.string(from: date)
+            self?.textField.sendActions(for: .valueChanged)
+        }
+    }
+    
+    func bind() {
+        datePicker.rx.date
+            .skip(1)
+            .distinctUntilChanged()
+            .asSignal(onErrorSignalWith: .empty())
+            .withUnretained(self)
+            .emit { owner, date in
+                
+                owner.updateTextField(date: date)
+                
+            }.disposed(by: disposeBag)
+    }
+    
 }
 
 // MARK: - Reactive Extension
@@ -126,5 +149,12 @@ extension Reactive where Base: ModalDatePicker {
     /// DatePicker의 날짜가 선택되면 해당 날짜를 이벤트로 방출하는 옵저버블
     var selectedDate: Observable<Date> {
         return base.datePicker.rx.date.asObservable()
+    }
+    
+    var isBlank: Observable<Bool> {
+        return base.textField.rx.text.orEmpty
+            .map { $0.count <= 0 }
+            .distinctUntilChanged()
+            .asObservable()
     }
 }

--- a/TripLog/TripLog/Feat-Crois/ModalViewController/View/ModalDateView.swift
+++ b/TripLog/TripLog/Feat-Crois/ModalViewController/View/ModalDateView.swift
@@ -19,6 +19,7 @@ final class ModalDateView: UIView {
     private let startDateIsBlank = BehaviorSubject<Bool>(value: true)
     private let endDateIsBlank = BehaviorSubject<Bool>(value: true)
     
+    /// 날짜가 모두 선택되었는지 검사하고 이벤트를 방출하는 옵저버블
     fileprivate lazy var dateIsBlank: Observable<Bool> = {
         return Observable
             .combineLatest(startDateIsBlank, endDateIsBlank)
@@ -114,6 +115,7 @@ private extension ModalDateView {
         }
     }
     
+    /// 데이터 바인딩 메소드
     func bind() {
         startDatePickerBind()
         endDatePickerBind()
@@ -140,11 +142,12 @@ private extension ModalDateView {
                 
             }.disposed(by: disposeBag)
         
-        startDatePicker.rx.isBlank
+        startDatePicker.rx.datePickerIsBlank
             .bind(to: startDateIsBlank)
             .disposed(by: disposeBag)
     }
     
+    /// EndDatePicker 바인딩 메소드
     func endDatePickerBind() {
         endDatePicker.rx.selectedDate
             .skip(2)
@@ -165,14 +168,17 @@ private extension ModalDateView {
                 
             }.disposed(by: disposeBag)
         
-        endDatePicker.rx.isBlank
+        endDatePicker.rx.datePickerIsBlank
             .bind(to: endDateIsBlank)
             .disposed(by: disposeBag)
     }
     
 }
 
+// MARK: - Reactive Extension
+
 extension Reactive where Base: ModalDateView {
+    /// 날짜가 선택되었는지 검사하고 이벤트를 방출하는 옵저버블
     var dateIsBlank: Observable<Bool> {
         return base.dateIsBlank
     }

--- a/TripLog/TripLog/Feat-Crois/ModalViewController/View/ModalTextField.swift
+++ b/TripLog/TripLog/Feat-Crois/ModalViewController/View/ModalTextField.swift
@@ -116,8 +116,11 @@ private extension ModalTextField {
     }
 }
 
+// MARK: - Reactive Extension
+
 extension Reactive where Base: ModalTextField {
-    var isBlank: Observable<Bool> {
+    /// 텍스트필드의 입력란이 비었는지 검사하고 이벤트를 방출하는 옵저버블
+    var textFieldIsBlank: Observable<Bool> {
         return base.textField.rx.text.orEmpty
             .map { $0.count <= 0 }
             .distinctUntilChanged()

--- a/TripLog/TripLog/Feat-Crois/ModalViewController/View/ModalTextField.swift
+++ b/TripLog/TripLog/Feat-Crois/ModalViewController/View/ModalTextField.swift
@@ -8,6 +8,8 @@
 import UIKit
 import SnapKit
 import Then
+import RxSwift
+import RxCocoa
 
 /// 모달에서 텍스트 입력을 받을 텍스트 필드 공용 컴포넌츠
 final class ModalTextField: UIView {
@@ -30,7 +32,7 @@ final class ModalTextField: UIView {
         $0.backgroundColor = .clear
     }
     
-    private let textField = UITextField().then {
+    fileprivate let textField = UITextField().then {
         $0.font = UIFont.SCDream(size: .body, weight: .regular)
         $0.textColor = UIColor.Dark.base
         $0.borderStyle = .none
@@ -111,5 +113,14 @@ private extension ModalTextField {
             $0.horizontalEdges.equalToSuperview()
             $0.bottom.equalToSuperview()
         }
+    }
+}
+
+extension Reactive where Base: ModalTextField {
+    var isBlank: Observable<Bool> {
+        return base.textField.rx.text.orEmpty
+            .map { $0.count <= 0 }
+            .distinctUntilChanged()
+            .asObservable()
     }
 }

--- a/TripLog/TripLog/Feat-Crois/ModalViewController/View/ModalView.swift
+++ b/TripLog/TripLog/Feat-Crois/ModalViewController/View/ModalView.swift
@@ -166,6 +166,7 @@ private extension ModalView {
         }
     }
     
+    /// 모달뷰를 세팅하는 메소드
     func setupModal() {
         switch self.state {
         case .createNewCashBook:
@@ -174,15 +175,15 @@ private extension ModalView {
                let thirdSection = self.thirdSection as? ModalTextField,
                let forthSection = self.forthSection as? ModalDateView
             {
-                firstSection.rx.isBlank
+                firstSection.rx.textFieldIsBlank
                     .bind(to: firstTextFieldIsBlank)
                     .disposed(by: disposeBag)
                 
-                secondSection.rx.isBlank
+                secondSection.rx.textFieldIsBlank
                     .bind(to: secondTextFieldIsBlank)
                     .disposed(by: disposeBag)
                 
-                thirdSection.rx.isBlank
+                thirdSection.rx.textFieldIsBlank
                     .bind(to: thirdTextFieldIsBlank)
                     .disposed(by: disposeBag)
                 
@@ -202,15 +203,15 @@ private extension ModalView {
                 thirdSection.configureTextField(text: "\(data.budget)")
                 forthSection.configureDate(start: data.startDate, end: data.endDate)
                 
-                firstSection.rx.isBlank
+                firstSection.rx.textFieldIsBlank
                     .bind(to: firstTextFieldIsBlank)
                     .disposed(by: disposeBag)
                 
-                secondSection.rx.isBlank
+                secondSection.rx.textFieldIsBlank
                     .bind(to: secondTextFieldIsBlank)
                     .disposed(by: disposeBag)
                 
-                thirdSection.rx.isBlank
+                thirdSection.rx.textFieldIsBlank
                     .bind(to: thirdTextFieldIsBlank)
                     .disposed(by: disposeBag)
                 
@@ -225,11 +226,11 @@ private extension ModalView {
                let thirdSection = self.thirdSection as? ModalTextField,
                let forthSection = self.forthSection as? ModalAmoutView
             {
-                secondSection.rx.isBlank
+                secondSection.rx.textFieldIsBlank
                     .bind(to: firstTextFieldIsBlank)
                     .disposed(by: disposeBag)
                 
-                thirdSection.rx.isBlank
+                thirdSection.rx.textFieldIsBlank
                     .bind(to: secondTextFieldIsBlank)
                     .disposed(by: disposeBag)
                 
@@ -249,11 +250,11 @@ private extension ModalView {
                 thirdSection.configureTextField(text: data.category)
                 forthSection.configureAmoutView(amout: data.amount, currency: data.carrency)
                 
-                secondSection.rx.isBlank
+                secondSection.rx.textFieldIsBlank
                     .bind(to: firstTextFieldIsBlank)
                     .disposed(by: disposeBag)
                 
-                thirdSection.rx.isBlank
+                thirdSection.rx.textFieldIsBlank
                     .bind(to: secondTextFieldIsBlank)
                     .disposed(by: disposeBag)
                 
@@ -290,7 +291,8 @@ extension Reactive where Base: ModalView {
         return base.cancelButtonTapped
     }
     
-    var observeTextFields: Observable<Bool> {
+    /// 빈 값인 섹션이 있는지 검사하고 이벤트를 방출하는 옵저버블
+    var checkBlankOfSections: Observable<Bool> {
         return base.allSectionIsBlank
     }
 }

--- a/TripLog/TripLog/Feat-Crois/ModalViewController/View/ModalView.swift
+++ b/TripLog/TripLog/Feat-Crois/ModalViewController/View/ModalView.swift
@@ -22,7 +22,7 @@ final class ModalView: UIView {
     private let firstTextFieldIsBlank = BehaviorSubject<Bool>(value: true)
     private let secondTextFieldIsBlank = BehaviorSubject<Bool>(value: true)
     private let thirdTextFieldIsBlank = BehaviorSubject<Bool>(value: true)
-    private let dateIsBlank = BehaviorSubject<Bool>(value: true)
+    private let dateIsBlank = BehaviorSubject<Bool>(value: false)
     
     fileprivate lazy var allSectionIsBlank: Observable<Bool> = {
         return Observable

--- a/TripLog/TripLog/Feat-Crois/ModalViewController/View/ModalView.swift
+++ b/TripLog/TripLog/Feat-Crois/ModalViewController/View/ModalView.swift
@@ -19,17 +19,19 @@ final class ModalView: UIView {
     fileprivate let cancelButtonTapped = PublishRelay<Void>()
     fileprivate let activeButtonTapped = PublishRelay<Void>()
     
-    fileprivate let firstTextFieldIsBlank = BehaviorSubject<Bool>(value: true)
-    fileprivate let secondTextFieldIsBlank = BehaviorSubject<Bool>(value: true)
-    fileprivate let thirdTextFieldIsBlank = BehaviorSubject<Bool>(value: true)
+    private let firstTextFieldIsBlank = BehaviorSubject<Bool>(value: true)
+    private let secondTextFieldIsBlank = BehaviorSubject<Bool>(value: true)
+    private let thirdTextFieldIsBlank = BehaviorSubject<Bool>(value: true)
+    private let dateIsBlank = BehaviorSubject<Bool>(value: true)
     
-    lazy var allTextFieldsAreBlank: Observable<Bool> = {
+    fileprivate lazy var allSectionIsBlank: Observable<Bool> = {
         return Observable
             .combineLatest(firstTextFieldIsBlank,
                            secondTextFieldIsBlank,
-                           thirdTextFieldIsBlank
+                           thirdTextFieldIsBlank,
+                           dateIsBlank
             )
-            .map { $0 && $1 && $2 }
+            .map { $0 || $1 || $2 || $3 }
             .distinctUntilChanged()
             .share(replay: 1, scope: .whileConnected)
     }()
@@ -169,7 +171,8 @@ private extension ModalView {
         case .createNewCashBook:
             if let firstSection = self.firstSection as? ModalTextField,
                let secondSection = self.secondSection as? ModalTextField,
-               let thirdSection = self.thirdSection as? ModalTextField
+               let thirdSection = self.thirdSection as? ModalTextField,
+               let forthSection = self.forthSection as? ModalDateView
             {
                 firstSection.rx.isBlank
                     .bind(to: firstTextFieldIsBlank)
@@ -181,6 +184,10 @@ private extension ModalView {
                 
                 thirdSection.rx.isBlank
                     .bind(to: thirdTextFieldIsBlank)
+                    .disposed(by: disposeBag)
+                
+                forthSection.rx.dateIsBlank
+                    .bind(to: dateIsBlank)
                     .disposed(by: disposeBag)
             }
             
@@ -205,6 +212,10 @@ private extension ModalView {
                 
                 thirdSection.rx.isBlank
                     .bind(to: thirdTextFieldIsBlank)
+                    .disposed(by: disposeBag)
+                
+                forthSection.rx.dateIsBlank
+                    .bind(to: dateIsBlank)
                     .disposed(by: disposeBag)
             }
             
@@ -280,6 +291,6 @@ extension Reactive where Base: ModalView {
     }
     
     var observeTextFields: Observable<Bool> {
-        return base.allTextFieldsAreBlank
+        return base.allSectionIsBlank
     }
 }

--- a/TripLog/TripLog/Feat-Crois/ModalViewController/View/ModalView.swift
+++ b/TripLog/TripLog/Feat-Crois/ModalViewController/View/ModalView.swift
@@ -33,10 +33,10 @@ final class ModalView: UIView {
     
     private let buttons: ModalButtons
     
-    private let firstSection: UIView?
-    private let secondSection: UIView?
-    private let thirdSection: UIView?
-    private let forthSection: UIView?
+    private let firstSection: UIView
+    private let secondSection: UIView
+    private let thirdSection: UIView
+    private let forthSection: UIView
     
     // MARK: - Properties
     
@@ -142,10 +142,10 @@ private extension ModalView {
         self.backgroundColor = UIColor.CustomColors.Background.background
         self.applyViewShadow()
         [titleLabel,
-         firstSection!,
-         secondSection!,
-         thirdSection!,
-         forthSection!,
+         firstSection,
+         secondSection,
+         thirdSection,
+         forthSection,
          buttons].forEach { self.addSubview($0) }
     }
     
@@ -155,32 +155,32 @@ private extension ModalView {
             $0.horizontalEdges.equalToSuperview().inset(24)
         }
         
-        firstSection?.snp.makeConstraints {
+        firstSection.snp.makeConstraints {
             $0.top.equalTo(titleLabel.snp.bottom).offset(16)
             $0.horizontalEdges.equalToSuperview().inset(24)
             $0.height.equalTo(66)
         }
         
-        secondSection?.snp.makeConstraints {
-            $0.top.equalTo(firstSection!.snp.bottom).offset(16)
+        secondSection.snp.makeConstraints {
+            $0.top.equalTo(firstSection.snp.bottom).offset(16)
             $0.horizontalEdges.equalToSuperview().inset(24)
             $0.height.equalTo(66)
         }
         
-        thirdSection?.snp.makeConstraints {
-            $0.top.equalTo(secondSection!.snp.bottom).offset(16)
+        thirdSection.snp.makeConstraints {
+            $0.top.equalTo(secondSection.snp.bottom).offset(16)
             $0.horizontalEdges.equalToSuperview().inset(24)
             $0.height.equalTo(66)
         }
         
-        forthSection?.snp.makeConstraints {
-            $0.top.equalTo(thirdSection!.snp.bottom).offset(16)
+        forthSection.snp.makeConstraints {
+            $0.top.equalTo(thirdSection.snp.bottom).offset(16)
             $0.horizontalEdges.equalToSuperview().inset(24)
             $0.height.equalTo(66)
         }
         
         buttons.snp.makeConstraints {
-            $0.top.equalTo(forthSection!.snp.bottom).offset(16)
+            $0.top.equalTo(forthSection.snp.bottom).offset(16)
             $0.horizontalEdges.equalToSuperview().inset(24)
             $0.height.equalTo(44)
         }

--- a/TripLog/TripLog/Feat-Crois/ModalViewController/View/ModalViewController.swift
+++ b/TripLog/TripLog/Feat-Crois/ModalViewController/View/ModalViewController.swift
@@ -81,7 +81,7 @@ private extension ModalViewController {
         let input: ModalViewModel.Input = .init(
             cancelButtonTapped: self.modalView.rx.cancelButtonTapped,
             activeButtonTapped: self.modalView.rx.activeButtonTapped,
-            textFieldIsBlank: self.modalView.rx.observeTextFields
+            sectionIsBlank: self.modalView.rx.observeTextFields
         )
         
         let output = viewModel.transform(input: input)

--- a/TripLog/TripLog/Feat-Crois/ModalViewController/View/ModalViewController.swift
+++ b/TripLog/TripLog/Feat-Crois/ModalViewController/View/ModalViewController.swift
@@ -80,7 +80,8 @@ private extension ModalViewController {
         
         let input: ModalViewModel.Input = .init(
             cancelButtonTapped: self.modalView.rx.cancelButtonTapped,
-            activeButtonTapped: self.modalView.rx.activeButtonTapped
+            activeButtonTapped: self.modalView.rx.activeButtonTapped,
+            textFieldIsBlank: self.modalView.rx.observeTextFields
         )
         
         let output = viewModel.transform(input: input)
@@ -88,7 +89,14 @@ private extension ModalViewController {
         output.active
             .asSignal(onErrorSignalWith: .empty())
             .withUnretained(self)
-            .emit { owner, _ in
+            .emit { owner, isBlank in
+                
+                guard !isBlank else {
+                    guard let vc = AppHelpers.getTopViewController() else { return }
+                    let alert = AlertManager(title: "알림", message: "모든 입력을 채워주세요!!", cancelTitle: "확인")
+                    alert.showAlert(on: vc, .alert)
+                    return
+                }
                 
                 switch owner.modalView.checkModalStatus() {
                 case .createNewCashBook: break

--- a/TripLog/TripLog/Feat-Crois/ModalViewController/View/ModalViewController.swift
+++ b/TripLog/TripLog/Feat-Crois/ModalViewController/View/ModalViewController.swift
@@ -81,7 +81,7 @@ private extension ModalViewController {
         let input: ModalViewModel.Input = .init(
             cancelButtonTapped: self.modalView.rx.cancelButtonTapped,
             activeButtonTapped: self.modalView.rx.activeButtonTapped,
-            sectionIsBlank: self.modalView.rx.observeTextFields
+            sectionIsBlank: self.modalView.rx.checkBlankOfSections
         )
         
         let output = viewModel.transform(input: input)

--- a/TripLog/TripLog/Feat-Crois/ModalViewController/ViewModel/ModalViewModel.swift
+++ b/TripLog/TripLog/Feat-Crois/ModalViewController/ViewModel/ModalViewModel.swift
@@ -15,7 +15,7 @@ final class ModalViewModel: ViewModelType {
     struct Input {
         let cancelButtonTapped: PublishRelay<Void>
         let activeButtonTapped: PublishRelay<Void>
-        let textFieldIsBlank: Observable<Bool>
+        let sectionIsBlank: Observable<Bool>
     }
     
     struct Output {
@@ -58,7 +58,7 @@ final class ModalViewModel: ViewModelType {
                 
             }.disposed(by: disposeBag)
         
-        input.textFieldIsBlank
+        input.sectionIsBlank
             .asSignal(onErrorSignalWith: .empty())
             .withUnretained(self)
             .emit { owner, isBlank in

--- a/TripLog/TripLog/Feat-Crois/ModalViewController/ViewModel/ModalViewModel.swift
+++ b/TripLog/TripLog/Feat-Crois/ModalViewController/ViewModel/ModalViewModel.swift
@@ -34,6 +34,7 @@ final class ModalViewModel: ViewModelType {
     /// - Parameter input:
     /// **cancelButtonTapped**: 취소 버튼의 탭 이벤트를 방출하는 옵저버블
     /// **activeButtonTapped**: active 버튼의 탭 이벤트를 방출하는 옵저버블
+    /// **sectionIsBlank**: 모달뷰의 섹션 중 빈 값이 있는지 검사하고 이벤트를 방출하는 옵저버블
     ///
     /// - Returns:
     /// **modalDismiss**: 취소 버튼이 눌리면 모달을 닫도록 이벤트를 방출하는 옵저버블

--- a/TripLog/TripLog/Feat-Crois/ModalViewController/ViewModel/ModalViewModel.swift
+++ b/TripLog/TripLog/Feat-Crois/ModalViewController/ViewModel/ModalViewModel.swift
@@ -15,17 +15,20 @@ final class ModalViewModel: ViewModelType {
     struct Input {
         let cancelButtonTapped: PublishRelay<Void>
         let activeButtonTapped: PublishRelay<Void>
+        let textFieldIsBlank: Observable<Bool>
     }
     
     struct Output {
         let modalDismiss: PublishRelay<Void>
-        let active: PublishRelay<Void>
+        let active: PublishRelay<Bool>
     }
     
     let disposeBag = DisposeBag()
     
     private let modalDismiss = PublishRelay<Void>()
-    private let active = PublishRelay<Void>()
+    private let active = PublishRelay<Bool>()
+    
+    private var textFieldIsBlank: Bool?
     
     /// input을 output으로 변환해주는 메소드
     /// - Parameter input:
@@ -41,7 +44,8 @@ final class ModalViewModel: ViewModelType {
             .withUnretained(self)
             .emit { owner, _ in
                 
-                owner.active.accept(())
+                guard let isBlank = owner.textFieldIsBlank else { return }
+                owner.active.accept(isBlank)
                 
             }.disposed(by: disposeBag)
         
@@ -51,6 +55,15 @@ final class ModalViewModel: ViewModelType {
             .emit { owner, _ in
                 
                 owner.modalDismiss.accept(())
+                
+            }.disposed(by: disposeBag)
+        
+        input.textFieldIsBlank
+            .asSignal(onErrorSignalWith: .empty())
+            .withUnretained(self)
+            .emit { owner, isBlank in
+                
+                owner.textFieldIsBlank = isBlank
                 
             }.disposed(by: disposeBag)
         


### PR DESCRIPTION
이슈 번호: close #32 

## 요약
- 모달뷰에서 빈 값이 있을 경우 사용자에게 알림
- 모든 값을 입력할 때까지 데이터 저장 로직이 진행되기 않고, 모달이 닫히지 않도록 구현
- 모달뷰 리팩토링(코드 수정, 중복코드 최소화 등)

## 작업 상세 내용
RxSwift를 활용하여 모달 내의 빈 값을 검사하고, 하나라도 빈 값이 있는 경우 
`Alert`을 통해 경고하고, 데이터 저장 로직이 실행되지 않습니다.

## 리뷰어 공유사항
현재는 모든 값을 입력한 경우에만 로직이 실행되도록 구현하였는데,
회의를 통해 특정 값만 필수 옵션으로 설정할지 정하는 것이 좋을 것 같습니다.

## 스크린샷(선택)

![무제](https://github.com/user-attachments/assets/5cd99087-0263-4ce4-95c1-cd76a948fdd5)
