### PR TITLE
🐛 [fix] Save&Fetch 버그 해결

### DIFF
--- a/TripLog/TripLog.xcodeproj/project.pbxproj
+++ b/TripLog/TripLog.xcodeproj/project.pbxproj
@@ -336,8 +336,11 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
-				CODE_SIGN_STYLE = Automatic;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = "";
+				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = G59RU3455W;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = TripLog/Application/Info.plist;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
@@ -352,6 +355,8 @@
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.Sparta-iOS-Tech-2team.TripLog";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "team-triplog";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
@@ -369,8 +374,11 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
-				CODE_SIGN_STYLE = Automatic;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = "";
+				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = G59RU3455W;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = TripLog/Application/Info.plist;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
@@ -385,6 +393,8 @@
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.Sparta-iOS-Tech-2team.TripLog";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "team-triplog";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
@@ -520,13 +530,15 @@
 			baseConfigurationReferenceRelativePath = "Application/Hamsik/API&CoreData/Secrets.xcconfig";
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
-				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = "";
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.Sparta-iOS-Tech-2team.TripLogTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
@@ -544,13 +556,15 @@
 			baseConfigurationReferenceRelativePath = "Application/Hamsik/API&CoreData/Secrets.xcconfig";
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
-				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = "";
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.Sparta-iOS-Tech-2team.TripLogTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
@@ -565,13 +579,15 @@
 		AAC9B0922D3A7073006892A7 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = "";
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.Sparta-iOS-Tech-2team.TripLogUITests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
@@ -586,13 +602,15 @@
 		AAC9B0932D3A7073006892A7 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = "";
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.Sparta-iOS-Tech-2team.TripLogUITests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;

--- a/TripLog/TripLog/Feat-Hamsik/Extension/CashBookEntity+Ext.swift
+++ b/TripLog/TripLog/Feat-Hamsik/Extension/CashBookEntity+Ext.swift
@@ -134,21 +134,16 @@ extension CashBookEntity: CoreDataManagable {
     }
     
     static func delete(entityID: UUID, context: NSManagedObjectContext) {
-        let persistantContainer = CoreDataManager.shared.persistentContainer
         let entityName = EntityKeys.Name.CashBookEntity.rawValue
         let element = CashBookElement()
-        // Core Data 모델에서 해당 entity가 존재하는지 확인
-        guard persistantContainer.managedObjectModel.entities.contains(where: { $0.value(forKey: element.id) as! UUID == entityID }) else {
-            debugPrint("삭제하려는 엔티티 '\(entityID)'가 존재하지 않습니다.")
-            return
-        }
+        
         let fetchRequest = NSFetchRequest<NSFetchRequestResult>(entityName: entityName)
         fetchRequest.predicate = NSPredicate(format: "\(element.id) == %@", entityID as CVarArg)
         let deleteRequest = NSBatchDeleteRequest(fetchRequest: fetchRequest)
         
         do {
             try context.execute(deleteRequest)
-            try context.save()
+            context.refreshAllObjects()
             debugPrint("\(entityName)에서 id \(entityID) 데이터 삭제 완료")
         } catch {
             debugPrint("\(entityName)에서 id \(entityID) 데이터 삭제 실패: \(error)")

--- a/TripLog/TripLog/Feat-Hamsik/Extension/CashBookEntity+Ext.swift
+++ b/TripLog/TripLog/Feat-Hamsik/Extension/CashBookEntity+Ext.swift
@@ -26,10 +26,10 @@ extension CashBookEntity: CoreDataManagable {
     
     static func save(_ data: Model, context: NSManagedObjectContext) {
         let entityName = EntityKeys.Name.CashBookEntity.rawValue
-        let element = EntityKeys.CashBookElement.self
+        let element = CashBookElement()
         guard let entity = NSEntityDescription.entity(forEntityName: entityName, in: context) else { return }
         let fetchRequest: NSFetchRequest<CashBookEntity> = CashBookEntity.fetchRequest()
-        fetchRequest.predicate = NSPredicate(format: "\(EntityKeys.CashBookElement.tripName) == %@", data.tripName as CVarArg)
+        fetchRequest.predicate = NSPredicate(format: "\(element.tripName) == %@", data.tripName as CVarArg)
         
         do {
             let existingItems = try context.fetch(fetchRequest)
@@ -68,6 +68,7 @@ extension CashBookEntity: CoreDataManagable {
     /// - Returns: 검색 결과
     static func fetch(context: NSManagedObjectContext, predicate: String? = nil) -> [Entity] {
         let request: NSFetchRequest<CashBookEntity> = CashBookEntity.fetchRequest()
+        let element = CashBookElement()
         
         guard let predicate = predicate else {
             // 검색 조건이 없을 때 동작
@@ -82,11 +83,11 @@ extension CashBookEntity: CoreDataManagable {
         }
         
         // 검색 조건이 있을 때 동작
-        request.predicate = NSPredicate(format: "\(EntityKeys.CashBookElement.tripName) == %@", predicate)
+        request.predicate = NSPredicate(format: "\(element.tripName) == %@", predicate)
         do {
             let result = try context.fetch(request)
             for item in result {
-                print("검색 결과: \n이름: \(item.value(forKey: EntityKeys.CashBookElement.tripName) ?? "")")
+                print("검색 결과: \n이름: \(item.value(forKey: element.tripName) ?? "")")
             }
             return result
         } catch {
@@ -102,7 +103,8 @@ extension CashBookEntity: CoreDataManagable {
     ///   - context: CoreData 인스턴스
     static func update(data: MockCashBookModel, entityID: UUID, context: NSManagedObjectContext) {
         let fetchRequest: NSFetchRequest<CashBookEntity> = CashBookEntity.fetchRequest()
-        fetchRequest.predicate = NSPredicate(format: "\(EntityKeys.CashBookElement.id) == %@", entityID as CVarArg)
+        let element = CashBookElement()
+        fetchRequest.predicate = NSPredicate(format: "\(element.id) == %@", entityID as CVarArg)
         
         do {
             let results = try context.fetch(fetchRequest)
@@ -110,11 +112,11 @@ extension CashBookEntity: CoreDataManagable {
             if let entityToUpdate = results.first {
                 // 비동기 저장
                 context.performAndWait {
-                    entityToUpdate.setValue(data.budget, forKey: EntityKeys.CashBookElement.budget)
-                    entityToUpdate.setValue(data.departure, forKey: EntityKeys.CashBookElement.departure)
-                    entityToUpdate.setValue(data.homecoming, forKey: EntityKeys.CashBookElement.homecoming)
-                    entityToUpdate.setValue(data.note, forKey: EntityKeys.CashBookElement.note)
-                    entityToUpdate.setValue(data.tripName, forKey: EntityKeys.CashBookElement.tripName)
+                    entityToUpdate.setValue(data.budget, forKey: element.budget)
+                    entityToUpdate.setValue(data.departure, forKey: element.departure)
+                    entityToUpdate.setValue(data.homecoming, forKey: element.homecoming)
+                    entityToUpdate.setValue(data.note, forKey: element.note)
+                    entityToUpdate.setValue(data.tripName, forKey: element.tripName)
                 }
                 do {
                     try context.save()
@@ -134,13 +136,14 @@ extension CashBookEntity: CoreDataManagable {
     static func delete(entityID: UUID, context: NSManagedObjectContext) {
         let persistantContainer = CoreDataManager.shared.persistentContainer
         let entityName = EntityKeys.Name.CashBookEntity.rawValue
+        let element = CashBookElement()
         // Core Data 모델에서 해당 entity가 존재하는지 확인
-        guard persistantContainer.managedObjectModel.entities.contains(where: { $0.value(forKey: EntityKeys.CashBookElement.id) as! UUID == entityID }) else {
+        guard persistantContainer.managedObjectModel.entities.contains(where: { $0.value(forKey: element.id) as! UUID == entityID }) else {
             debugPrint("삭제하려는 엔티티 '\(entityID)'가 존재하지 않습니다.")
             return
         }
         let fetchRequest = NSFetchRequest<NSFetchRequestResult>(entityName: entityName)
-        fetchRequest.predicate = NSPredicate(format: "\(EntityKeys.CashBookElement.id) == %@", entityID as CVarArg)
+        fetchRequest.predicate = NSPredicate(format: "\(element.id) == %@", entityID as CVarArg)
         let deleteRequest = NSBatchDeleteRequest(fetchRequest: fetchRequest)
         
         do {

--- a/TripLog/TripLog/Feat-Hamsik/Extension/CashBookEntity+Ext.swift
+++ b/TripLog/TripLog/Feat-Hamsik/Extension/CashBookEntity+Ext.swift
@@ -26,27 +26,29 @@ extension CashBookEntity: CoreDataManagable {
     
     static func save(_ data: Model, context: NSManagedObjectContext) {
         let entityName = EntityKeys.Name.CashBookEntity.rawValue
+        let element = EntityKeys.CashBookElement.self
         guard let entity = NSEntityDescription.entity(forEntityName: entityName, in: context) else { return }
         let fetchRequest: NSFetchRequest<CashBookEntity> = CashBookEntity.fetchRequest()
-        fetchRequest.predicate = NSPredicate(format: "id == %@", data.id as CVarArg)
+        fetchRequest.predicate = NSPredicate(format: "tripName == %@", data.tripName as CVarArg)
         
         do {
             let existingItems = try context.fetch(fetchRequest)
             if existingItems.isEmpty {
                 // 중복된 항목이 없으면 저장
-                context.perform {
+                context.performAndWait {
                     let att = NSManagedObject(entity: entity, insertInto: context)
-                    att.setValue(data.budget, forKey: EntityKeys.CashBookElement.budget)
-                    att.setValue(data.departure, forKey: EntityKeys.CashBookElement.departure)
-                    att.setValue(data.homecoming, forKey: EntityKeys.CashBookElement.homecoming)
-                    att.setValue(data.note, forKey: EntityKeys.CashBookElement.note)
-                    att.setValue(data.tripName, forKey: EntityKeys.CashBookElement.tripName)
-                }
-                do {
-                    try context.save()
-                    print("저장 성공: \(data.note)")
-                } catch {
-                    print("데이터 저장 실패: \(error)")
+                    att.setValue(data.id, forKey: "id")
+                    att.setValue(data.budget, forKey: element.budget)
+                    att.setValue(data.departure, forKey: element.departure)
+                    att.setValue(data.homecoming, forKey: element.homecoming)
+                    att.setValue(data.note, forKey: element.note)
+                    att.setValue(data.tripName, forKey: element.tripName)
+                    do {
+                        try context.save()
+                        print("저장 성공: \(data.note)")
+                    } catch {
+                        print("데이터 저장 실패: \(error)")
+                    }
                 }
             } else {
                 print("이미 존재하는 항목입니다.")
@@ -70,7 +72,7 @@ extension CashBookEntity: CoreDataManagable {
             // 검색 조건이 없을 때 동작
             do {
                 let result = try context.fetch(request)
-                print("모든 CashBookEntity fetch 성공")
+                print("모든 CashBookEntity fetch 성공: \(result.count)")
                 return result
             } catch {
                 print("CashBookEntity Fetch 실패: \(error)")
@@ -79,7 +81,7 @@ extension CashBookEntity: CoreDataManagable {
         }
         
         // 검색 조건이 있을 때 동작
-        request.predicate = NSPredicate(format: "tripName == $@", predicate)
+        request.predicate = NSPredicate(format: "tripName == %@", predicate)
         do {
             let result = try context.fetch(request)
             for item in result {
@@ -105,7 +107,7 @@ extension CashBookEntity: CoreDataManagable {
             let results = try context.fetch(fetchRequest)
             
             if let entityToUpdate = results.first {
-                context.perform {
+                context.performAndWait {
                     entityToUpdate.setValue(data.budget, forKey: EntityKeys.CashBookElement.budget)
                     entityToUpdate.setValue(data.departure, forKey: EntityKeys.CashBookElement.departure)
                     entityToUpdate.setValue(data.homecoming, forKey: EntityKeys.CashBookElement.homecoming)

--- a/TripLog/TripLog/Feat-Hamsik/Extension/CurrencyEntity+Ext.swift
+++ b/TripLog/TripLog/Feat-Hamsik/Extension/CurrencyEntity+Ext.swift
@@ -78,7 +78,7 @@ extension CurrencyEntity: CoreDataManagable {
         ///   - date: 요청한 환율정보의 날짜
         ///   - context: CoreData 인스턴스
         func saveToCoreData(_ currencyRates: CurrencyRate, date: String, context: NSManagedObjectContext) {
-            let keys = EntityKeys.CurrencyElement.self
+            let element = CurrencyElement()
             print("dataCount: \(currencyRates.count)")
             guard let entity = NSEntityDescription.entity(
                 forEntityName: EntityKeys.Name.CurrencyEntity.rawValue, in: context
@@ -86,10 +86,10 @@ extension CurrencyEntity: CoreDataManagable {
             context.perform {
                 for item in currencyRates {
                     let entity = NSManagedObject(entity: entity, insertInto: context)
-                    entity.setValue(date, forKey: keys.rateDate)
-                    entity.setValue(item.curUnit, forKey: keys.currencyCode)
-                    entity.setValue(item.curNm, forKey: keys.currencyName)
-                    entity.setValue(Double(item.dealBasR?.replacingOccurrences(of: ",", with: "") ?? "1") ?? 1.0, forKey: keys.baseRate)
+                    entity.setValue(date, forKey: element.rateDate)
+                    entity.setValue(item.curUnit, forKey: element.currencyCode)
+                    entity.setValue(item.curNm, forKey: element.currencyName)
+                    entity.setValue(Double(item.dealBasR?.replacingOccurrences(of: ",", with: "") ?? "1") ?? 1.0, forKey: element.baseRate)
                 }
                 do {
                     try context.save()

--- a/TripLog/TripLog/Feat-Hamsik/Extension/MyCashBookEntity+Ext.swift
+++ b/TripLog/TripLog/Feat-Hamsik/Extension/MyCashBookEntity+Ext.swift
@@ -30,7 +30,7 @@ extension MyCashBookEntity: CoreDataManagable {
     ///   - context: CoreData 인스턴스
     static func save(_ data: Model, context: NSManagedObjectContext) {
         let entityName = EntityKeys.Name.MyCashBookEntity.rawValue
-        let element = EntityKeys.MyCashBookElement.self
+        let element = MyCashBookElement()
         guard let entity = NSEntityDescription.entity(forEntityName: entityName, in: context) else { return }
         
         // 비동기 저장
@@ -59,6 +59,7 @@ extension MyCashBookEntity: CoreDataManagable {
     /// - Returns: 검색 결과
     static func fetch(context: NSManagedObjectContext, predicate: String? = nil) -> [Entity] {
         let request: NSFetchRequest<MyCashBookEntity> = MyCashBookEntity.fetchRequest()
+        let element = MyCashBookElement()
         
         guard let predicate = predicate else {
             // 검색 조건이 없을 때 동작
@@ -73,11 +74,11 @@ extension MyCashBookEntity: CoreDataManagable {
         }
         
         // 검색 조건이 있을 때 동작
-        request.predicate = NSPredicate(format: "\(EntityKeys.MyCashBookElement.note) == %@", predicate)
+        request.predicate = NSPredicate(format: "\(element.note) == %@", predicate)
         do {
             let result = try context.fetch(request)
             for item in result {
-                print("검색 결과: \n이름: \(item.value(forKey: EntityKeys.MyCashBookElement.note) ?? "")")
+                print("검색 결과: \n이름: \(item.value(forKey: element.note) ?? "")")
             }
             return result
         } catch {
@@ -94,7 +95,8 @@ extension MyCashBookEntity: CoreDataManagable {
     ///   - context: CoreData 인스턴스
     static func update(data: MockMyCashBookModel, entityID: UUID, context: NSManagedObjectContext) {
         let fetchRequest: NSFetchRequest<MyCashBookEntity> = MyCashBookEntity.fetchRequest()
-        fetchRequest.predicate = NSPredicate(format: "\(EntityKeys.MyCashBookElement.id) == %@", entityID as CVarArg)
+        let element = MyCashBookElement()
+        fetchRequest.predicate = NSPredicate(format: "\(element.id) == %@", entityID as CVarArg)
         
         do {
             let results = try context.fetch(fetchRequest)
@@ -102,10 +104,10 @@ extension MyCashBookEntity: CoreDataManagable {
             if let entityToUpdate = results.first {
                 // 비동기 저장
                 context.performAndWait {
-                    entityToUpdate.setValue(data.amount, forKey: EntityKeys.MyCashBookElement.amount)
-                    entityToUpdate.setValue(data.category, forKey: EntityKeys.MyCashBookElement.category)
-                    entityToUpdate.setValue(data.note, forKey: EntityKeys.MyCashBookElement.note)
-                    entityToUpdate.setValue(data.payment, forKey: EntityKeys.MyCashBookElement.payment)
+                    entityToUpdate.setValue(data.amount, forKey: element.amount)
+                    entityToUpdate.setValue(data.category, forKey: element.category)
+                    entityToUpdate.setValue(data.note, forKey: element.note)
+                    entityToUpdate.setValue(data.payment, forKey: element.payment)
                 }
                 do {
                     try context.save()
@@ -125,13 +127,14 @@ extension MyCashBookEntity: CoreDataManagable {
     static func delete(entityID: UUID, context: NSManagedObjectContext) {
         let persistantContainer = CoreDataManager.shared.persistentContainer
         let entityName = EntityKeys.Name.MyCashBookEntity.rawValue
+        let element = MyCashBookElement()
         // Core Data 모델에서 해당 entity가 존재하는지 확인
-        guard persistantContainer.managedObjectModel.entities.contains(where: { $0.value(forKey: EntityKeys.MyCashBookElement.id) as! UUID == entityID }) else {
+        guard persistantContainer.managedObjectModel.entities.contains(where: { $0.value(forKey: element.id) as! UUID == entityID }) else {
             debugPrint("삭제하려는 엔티티 '\(entityID)'가 존재하지 않습니다.")
             return
         }
         let fetchRequest = NSFetchRequest<NSFetchRequestResult>(entityName: entityName)
-        fetchRequest.predicate = NSPredicate(format: "\(EntityKeys.MyCashBookElement.id) == %@", entityID as CVarArg)
+        fetchRequest.predicate = NSPredicate(format: "\(element.id) == %@", entityID as CVarArg)
         let deleteRequest = NSBatchDeleteRequest(fetchRequest: fetchRequest)
         
         do {

--- a/TripLog/TripLog/Feat-Hamsik/Extension/MyCashBookEntity+Ext.swift
+++ b/TripLog/TripLog/Feat-Hamsik/Extension/MyCashBookEntity+Ext.swift
@@ -33,9 +33,7 @@ extension MyCashBookEntity: CoreDataManagable {
         let element = EntityKeys.MyCashBookElement.self
         guard let entity = NSEntityDescription.entity(forEntityName: entityName, in: context) else { return }
         
-        let fetchRequest: NSFetchRequest<MyCashBookEntity> = MyCashBookEntity.fetchRequest()
-        fetchRequest.predicate = NSPredicate(format: "id == %@", data.id as CVarArg)
-        
+        // 비동기 저장
         context.performAndWait {
             let att = NSManagedObject(entity: entity, insertInto: context)
             att.setValue(data.id, forKey: element.id)
@@ -75,11 +73,11 @@ extension MyCashBookEntity: CoreDataManagable {
         }
         
         // 검색 조건이 있을 때 동작
-        request.predicate = NSPredicate(format: "note == %@", predicate)
+        request.predicate = NSPredicate(format: "\(EntityKeys.MyCashBookElement.note) == %@", predicate)
         do {
             let result = try context.fetch(request)
             for item in result {
-                print("검색 결과: \n이름: \(item.value(forKey: "note") ?? "")")
+                print("검색 결과: \n이름: \(item.value(forKey: EntityKeys.MyCashBookElement.note) ?? "")")
             }
             return result
         } catch {
@@ -96,12 +94,13 @@ extension MyCashBookEntity: CoreDataManagable {
     ///   - context: CoreData 인스턴스
     static func update(data: MockMyCashBookModel, entityID: UUID, context: NSManagedObjectContext) {
         let fetchRequest: NSFetchRequest<MyCashBookEntity> = MyCashBookEntity.fetchRequest()
-        fetchRequest.predicate = NSPredicate(format: "id == %@", entityID as CVarArg)
+        fetchRequest.predicate = NSPredicate(format: "\(EntityKeys.MyCashBookElement.id) == %@", entityID as CVarArg)
         
         do {
             let results = try context.fetch(fetchRequest)
             
             if let entityToUpdate = results.first {
+                // 비동기 저장
                 context.performAndWait {
                     entityToUpdate.setValue(data.amount, forKey: EntityKeys.MyCashBookElement.amount)
                     entityToUpdate.setValue(data.category, forKey: EntityKeys.MyCashBookElement.category)
@@ -127,12 +126,12 @@ extension MyCashBookEntity: CoreDataManagable {
         let persistantContainer = CoreDataManager.shared.persistentContainer
         let entityName = EntityKeys.Name.MyCashBookEntity.rawValue
         // Core Data 모델에서 해당 entity가 존재하는지 확인
-        guard persistantContainer.managedObjectModel.entities.contains(where: { $0.value(forKey: "id") as! UUID == entityID }) else {
+        guard persistantContainer.managedObjectModel.entities.contains(where: { $0.value(forKey: EntityKeys.MyCashBookElement.id) as! UUID == entityID }) else {
             debugPrint("삭제하려는 엔티티 '\(entityID)'가 존재하지 않습니다.")
             return
         }
         let fetchRequest = NSFetchRequest<NSFetchRequestResult>(entityName: entityName)
-        fetchRequest.predicate = NSPredicate(format: "id == %@", entityID as CVarArg)
+        fetchRequest.predicate = NSPredicate(format: "\(EntityKeys.MyCashBookElement.id) == %@", entityID as CVarArg)
         let deleteRequest = NSBatchDeleteRequest(fetchRequest: fetchRequest)
         
         do {

--- a/TripLog/TripLog/Feat-Hamsik/Extension/MyCashBookEntity+Ext.swift
+++ b/TripLog/TripLog/Feat-Hamsik/Extension/MyCashBookEntity+Ext.swift
@@ -7,9 +7,16 @@
 
 import Foundation
 import CoreData
+import Differentiator
 
 // TODO: 임시데이터(삭제예정)
-struct MockMyCashBookModel {
+struct MockMyCashBookModel: Hashable, IdentifiableType {
+    
+    typealias Identity = UUID
+    var identity: UUID {
+        self.id
+    }
+    
     var id = UUID()
     let note: String
     let category: String
@@ -125,21 +132,16 @@ extension MyCashBookEntity: CoreDataManagable {
     }
     
     static func delete(entityID: UUID, context: NSManagedObjectContext) {
-        let persistantContainer = CoreDataManager.shared.persistentContainer
         let entityName = EntityKeys.Name.MyCashBookEntity.rawValue
         let element = MyCashBookElement()
-        // Core Data 모델에서 해당 entity가 존재하는지 확인
-        guard persistantContainer.managedObjectModel.entities.contains(where: { $0.value(forKey: element.id) as! UUID == entityID }) else {
-            debugPrint("삭제하려는 엔티티 '\(entityID)'가 존재하지 않습니다.")
-            return
-        }
+        
         let fetchRequest = NSFetchRequest<NSFetchRequestResult>(entityName: entityName)
         fetchRequest.predicate = NSPredicate(format: "\(element.id) == %@", entityID as CVarArg)
         let deleteRequest = NSBatchDeleteRequest(fetchRequest: fetchRequest)
         
         do {
             try context.execute(deleteRequest)
-            try context.save()
+            context.refreshAllObjects()
             debugPrint("\(entityName)에서 id \(entityID) 데이터 삭제 완료")
         } catch {
             debugPrint("\(entityName)에서 id \(entityID) 데이터 삭제 실패: \(error)")

--- a/TripLog/TripLog/Feat-Hamsik/Utility/Entities.swift
+++ b/TripLog/TripLog/Feat-Hamsik/Utility/Entities.swift
@@ -12,28 +12,28 @@ enum EntityKeys {
     enum Name: String {
         case CurrencyEntity, CashBookEntity, MyCashBookEntity
     }
-    
-    enum CurrencyElement {
-        static let rateDate = "rateDate"
-        static let baseRate = "baseRate"
-        static let currencyCode = "currencyCode"
-        static let currencyName = "currencyName"
-    }
-    
-    enum CashBookElement {
-        static let id = "id"
-        static let budget = "budget"
-        static let departure = "departure"
-        static let homecoming = "homecoming"
-        static let note = "note"
-        static let tripName = "tripName"
-    }
-    
-    enum MyCashBookElement {
-        static let id = "id"
-        static let note = "note"
-        static let category = "category"
-        static let amount = "amount"
-        static let payment = "payment"
-    }
+}
+struct CurrencyElement {
+    let rateDate = "rateDate"
+    let baseRate = "baseRate"
+    let currencyCode = "currencyCode"
+    let currencyName = "currencyName"
+}
+
+struct MyCashBookElement {
+    let id = "id"
+    let note = "note"
+    let category = "category"
+    let amount = "amount"
+    let payment = "payment"
+}
+
+struct CashBookElement {
+    let id = "id"
+    let budget = "budget"
+    let departure = "departure"
+    let homecoming = "homecoming"
+    let note = "note"
+    let tripName = "tripName"
+
 }

--- a/TripLog/TripLog/Feat-Hamsik/Utility/Entities.swift
+++ b/TripLog/TripLog/Feat-Hamsik/Utility/Entities.swift
@@ -21,6 +21,7 @@ enum EntityKeys {
     }
     
     enum CashBookElement {
+        static let id = "id"
         static let budget = "budget"
         static let departure = "departure"
         static let homecoming = "homecoming"
@@ -29,6 +30,7 @@ enum EntityKeys {
     }
     
     enum MyCashBookElement {
+        static let id = "id"
         static let note = "note"
         static let category = "category"
         static let amount = "amount"


### PR DESCRIPTION
이슈 번호: close #64 

## 요약
- 중복저장 관련 이슈 해결
- 저장 후 fetch 되지 않는 현상 해결

## 작업 상세 내용
### 중복 저장 가능 객체/비객체 수정
- `CashBookEntity` :`id`가 아닌 `tripName`처럼 고유한 가계부 이름 작성을 유도하여 중복저장을 방지
```swift
fetchRequest.predicate = NSPredicate(format: "tripName == %@", data.tripName as CVarArg)
```
- `MyCashBookEntity` : 지출내역 특성상 중복저장을 허용

### 저장 후 fetch 되지 않는 현상
- `CoreData`에 데이터 저장되는 시간이 있어 `fetch`를 바로 호출 시 출력이 되지않음
- `performAndWait`를 사용하여 비동기적으로 진행
```swift
context.performAndWait { }
```
