### PR TITLE
[Fix] 다크모드/라이트모드 설정 기억

### DIFF
--- a/TripLog/TripLog/Application/SceneDelegate.swift
+++ b/TripLog/TripLog/Application/SceneDelegate.swift
@@ -14,6 +14,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
         guard let scene = (scene as? UIWindowScene) else { return }
         let window = UIWindow(windowScene: scene)
+        ThemeManager.loadTheme(for: window)
         window.rootViewController = UINavigationController(rootViewController: MainViewController())
         window.makeKeyAndVisible()
         

--- a/TripLog/TripLog/Feat-Crois/SettingViewController/Model/SettingTableCellModel.swift
+++ b/TripLog/TripLog/Feat-Crois/SettingViewController/Model/SettingTableCellModel.swift
@@ -56,7 +56,7 @@ private extension SettingTableCellModel {
     /// - Returns: UISwitch
     static func setupSwitch() -> UISwitch {
         let toggleSwitch = UISwitch()
-        let isDarkMode = UITraitCollection.current.userInterfaceStyle == .dark
+        let isDarkMode = UserDefaults.standard.object(forKey: "isDarkModeEnabled") == nil ? UITraitCollection.current.userInterfaceStyle == .dark : UserDefaults.standard.bool(forKey: "isDarkModeEnabled")
         toggleSwitch.isOn = isDarkMode
         toggleSwitch.thumbTintColor = .CustomColors.Background.detailBackground
         toggleSwitch.onTintColor = .Personal.normal

--- a/TripLog/TripLog/MainViewController.swift
+++ b/TripLog/TripLog/MainViewController.swift
@@ -52,14 +52,14 @@ class MainViewController: UIViewController {
 private extension MainViewController {
     
     func setupUI() {
-        configureSelf()
-        setupLayout()
-        playLottie()
-        
         // TabBarController 삽입
         addChild(mainVC)
         view.addSubview(mainVC.view)
         mainVC.didMove(toParent: self)
+        
+        configureSelf()
+        setupLayout()
+        playLottie()
     }
     
     func configureSelf() {

--- a/TripLog/TripLog/Source/AppHelpers/ThemeManager.swift
+++ b/TripLog/TripLog/Source/AppHelpers/ThemeManager.swift
@@ -41,7 +41,13 @@ final class ThemeManager {
     /// 현재 앱의 테마 상태를 확인하고 테마를 변경시키는 메소드
     /// - Parameter window: 테마를 변경할 window
     static func loadTheme(for window: UIWindow?) {
-        let isDarkMode = UserDefaults.standard.bool(forKey: "isDarkModeEnabled")
-        applyDarkMode(isDarkMode, for: window)
+        if UserDefaults.standard.object(forKey: "isDarkModeEnabled") == nil {
+            let isDarkMode = UITraitCollection.current.userInterfaceStyle == .dark
+            applyDarkMode(isDarkMode, for: window)
+        } else {
+            let isDarkMode = UserDefaults.standard.bool(forKey: "isDarkModeEnabled")
+            applyDarkMode(isDarkMode, for: window)
+        }
+        
     }
 }


### PR DESCRIPTION
이슈 번호: close #67 

## 요약
- 설정에서 앱의 다크모드/라이트모드를 설정했을 때 이를 기억하도록 로직을 수정했습니다.
- 안정성 향상을 위해 `UserDefaults`에 다크모드에 대한 값이 없을 경우 디바이스 설정을 따라가도록 수정

## 작업 상세 내용
`SceneDelegate`에 다크모드/라이트모드 전환 기능을 추가하여 앱 실행시 자연스럽게 앱의 설정에 맞는 모드가 되도록 설정했습니다.
외에도 다크모드/라이트모드 전환의 안정성을 향상시키는 로직을 추가했습니다.

## 리뷰어 공유사항
`Lottie`가 작동 안하면 테마가 부자연스럽게 바뀝니다.

## 스크린샷(선택)
![무제](https://github.com/user-attachments/assets/9108e84d-48dc-4606-afa5-2d4fbebb5587)
