### PR TITLE
[Refactor] 모달뷰 데이터 저장/업데이트 로직 리팩토링

### DIFF
--- a/TripLog/TripLog/Feat-Crois/ModalViewController/Model/Currencys.swift
+++ b/TripLog/TripLog/Feat-Crois/ModalViewController/Model/Currencys.swift
@@ -9,7 +9,7 @@ import Foundation
 
 /// 모든 통화를 모아두는 enum
 enum Currency: String, CaseIterable {
-    case KRW = "원(한화)"         // 대한민국
+    case KRW = "KRW(원)"         // 대한민국
     case USD = "USD(달러)"       // 미국
     case EUR = "EUR(유로)"       // 유럽 연합
     case JPY = "JPY(엔)"         // 일본

--- a/TripLog/TripLog/Feat-Crois/ModalViewController/Model/ModalViewState.swift
+++ b/TripLog/TripLog/Feat-Crois/ModalViewController/Model/ModalViewState.swift
@@ -11,7 +11,7 @@ import Foundation
 enum ModalViewState {
     case createNewCashBook
     case editCashBook(data: MockCashBookModel) // 가계부 수정시 데이터 입력
-    case createNewConsumption
+    case createNewConsumption(cashBookID: UUID, date: Date)
     case editConsumption(data: MockMyCashBookModel) // 지출 내역 수정 시 데이터 입력
     
     /// 각 상태에 따라 모달 뷰의 타이틀을 결정하는 프로퍼티

--- a/TripLog/TripLog/Feat-Crois/ModalViewController/View/ModalAmountView.swift
+++ b/TripLog/TripLog/Feat-Crois/ModalViewController/View/ModalAmountView.swift
@@ -74,9 +74,11 @@ final class ModalAmountView: UIView {
     /// - Parameters:
     ///   - amout: 금액(빈 값일 수도 있음)
     ///   - currency: 통화
-    func configureAmoutView(amout: Double?, currency: Currency) {
+    func configureAmoutView(amout: Double?, country: String) {
         self.textField.text = "\(amout ?? 0)"
-        self.currencyButton.setTitle(currency.rawValue, for: .normal)
+        
+        let currency = Currency.allCurrencies.filter { String($0.prefix(3)) == country }.first
+        self.currencyButton.setTitle(currency ?? "", for: .normal)
     }
     
     /// 금액뷰의 데이터를 추출하는 메소드
@@ -88,6 +90,11 @@ final class ModalAmountView: UIView {
         else { return 0 }
         
         return amount
+    }
+    
+    func currencyExtraction() -> String {
+        guard let currency = currencyButton.titleLabel?.text else { return "" }
+        return String(currency.prefix(3))
     }
     
 }

--- a/TripLog/TripLog/Feat-Crois/ModalViewController/View/ModalAmountView.swift
+++ b/TripLog/TripLog/Feat-Crois/ModalViewController/View/ModalAmountView.swift
@@ -26,7 +26,7 @@ final class ModalAmountView: UIView {
     }
     
     private let currencyButton = UIButton().then {
-        $0.setTitle("원(한화)", for: .normal)
+        $0.setTitle("KRW(원)", for: .normal)
         $0.setTitleColor(UIColor.Personal.normal, for: .normal)
         $0.titleLabel?.font = UIFont.SCDream(size: .headline, weight: .medium)
         $0.setImage(UIImage(systemName: "chevron.up.chevron.down"), for: .normal)
@@ -92,6 +92,8 @@ final class ModalAmountView: UIView {
         return amount
     }
     
+    /// 모달뷰의 금액뷰에서 통화 정보를 추출하는 메소드
+    /// - Returns: 통화 정보
     func currencyExtraction() -> String {
         guard let currency = currencyButton.titleLabel?.text else { return "" }
         return String(currency.prefix(3))

--- a/TripLog/TripLog/Feat-Crois/ModalViewController/View/ModalView.swift
+++ b/TripLog/TripLog/Feat-Crois/ModalViewController/View/ModalView.swift
@@ -13,8 +13,8 @@ import RxCocoa
 
 /// 모달 뷰 컨트롤러의 뷰로 쓰일 모달 뷰
 final class ModalView: UIView {
-    typealias ModalCashBookData = (id: UUID, tripName: String, note: String, budget: Int,departure: String, homecoming: String)
-    typealias ModalConsumptionData = (id: UUID, cashBookID: UUID, expenseDate: Date, payment: Bool, note: String, category: String, amount: Double, country: String)
+    typealias ModalCashBookData = (id: UUID, tripName: String, note: String, budget: Int,departure: String, homecoming: String, state: ModalViewState)
+    typealias ModalConsumptionData = (id: UUID, cashBookID: UUID, expenseDate: Date, payment: Bool, note: String, category: String, amount: Double, country: String, state: ModalViewState)
     
     // MARK: - Rx Properties
     
@@ -108,12 +108,6 @@ final class ModalView: UIView {
         super.layoutSubviews()
         
         self.layer.shadowPath = self.shadowPath()
-    }
-    
-    /// 모달뷰의 현재 상태를 반환하는 메소드
-    /// - Returns: 모달뷰의 현재 state
-    func checkModalStatus() -> ModalViewState {
-        return self.state
     }
 
 }
@@ -325,7 +319,8 @@ private extension ModalView {
                                 second.textFieldExtraction(),
                                 Int(third.textFieldExtraction()) ?? 0,
                                 dateData.start,
-                                dateData.end)
+                                dateData.end,
+                                state)
             
             return cashBookData
             
@@ -353,7 +348,8 @@ private extension ModalView {
                                    second.textFieldExtraction(),
                                    third.textFieldExtraction(),
                                    forth.amountExtraction(),
-                                   forth.currencyExtraction())
+                                   forth.currencyExtraction(),
+                                   state)
         
             return consumptionData
             
@@ -369,7 +365,7 @@ private extension ModalView {
             buttons.rx.activeButtondTapped
                 .map { [weak self] _ -> ModalView.ModalCashBookData in
                     guard let data = self?.cashBookDataExtraction() else {
-                        return (UUID(), "", "", 0, "", "")
+                        return (UUID(), "", "", 0, "", "", ModalViewState.createNewCashBook)
                     }
                     
                     return data
@@ -381,7 +377,7 @@ private extension ModalView {
             buttons.rx.activeButtondTapped
                 .map { [weak self] _ -> ModalView.ModalConsumptionData in
                     guard let data = self?.consumptionDataExtraction() else {
-                        return (UUID(), UUID(), Date(), false, "", "", 0, "")
+                        return (UUID(), UUID(), Date(), false, "", "", 0, "", ModalViewState.createNewCashBook)
                     }
                     
                     return data

--- a/TripLog/TripLog/Feat-Crois/ModalViewController/View/ModalView.swift
+++ b/TripLog/TripLog/Feat-Crois/ModalViewController/View/ModalView.swift
@@ -346,8 +346,8 @@ private extension ModalView {
                 let forth = forthSection as? ModalAmountView
             else { return nil }
             
-            let consumptionData = (getCashBookID(),
-                                   getConsumptionID(),
+            let consumptionData = (getConsumptionID(),
+                                   getCashBookID(),
                                    getExpenseDate(),
                                    first.paymentExtraction(),
                                    second.textFieldExtraction(),

--- a/TripLog/TripLog/Feat-Crois/ModalViewController/View/ModalViewController.swift
+++ b/TripLog/TripLog/Feat-Crois/ModalViewController/View/ModalViewController.swift
@@ -148,7 +148,6 @@ private extension ModalViewController {
                 case .createNewConsumption:
                     // 지출내역을 코어 데이터에 추가하는 로직
                     CoreDataManager.shared.save(type: MyCashBookEntity.self, data: consumptionData)
-                    print(data.1.cashBookID, data.1.expenseDate)
                 case .editConsumption:
                     // 지출내역을 코어 데이터에 업데이트 하는 로직
                     CoreDataManager.shared.update(type: MyCashBookEntity.self, entityID: data.1.id, data: consumptionData)

--- a/TripLog/TripLog/Feat-Crois/ModalViewController/View/ModalViewController.swift
+++ b/TripLog/TripLog/Feat-Crois/ModalViewController/View/ModalViewController.swift
@@ -107,7 +107,7 @@ private extension ModalViewController {
                                                         departure: data.1.departure,
                                                         homecoming: data.1.homecoming)
                 
-                switch owner.modalView.checkModalStatus() {
+                switch data.1.state {
                 case .createNewCashBook:
                     // 가계부를 코어 데이터에 추가하는 로직
                     CoreDataManager.shared.save(type: CashBookEntity.self, data: cashBookData)
@@ -143,8 +143,8 @@ private extension ModalViewController {
                                                              expenseDate: data.1.expenseDate,
                                                              note: data.1.note,
                                                              payment: data.1.payment)
-                
-                switch owner.modalView.checkModalStatus() {
+                                
+                switch data.1.state {
                 case .createNewConsumption:
                     // 지출내역을 코어 데이터에 추가하는 로직
                     CoreDataManager.shared.save(type: MyCashBookEntity.self, data: consumptionData)

--- a/TripLog/TripLog/Feat-Crois/ModalViewController/View/ModalViewController.swift
+++ b/TripLog/TripLog/Feat-Crois/ModalViewController/View/ModalViewController.swift
@@ -101,20 +101,20 @@ private extension ModalViewController {
                     return
                 }
                 
-                let result = CashBookEntity.Model(tripName: data.1.tripName,
-                                                note: data.1.note,
-                                                budget: data.1.budget,
-                                                departure: data.1.departure,
-                                                homecoming: data.1.homecoming)
+                let cashBookData = CashBookEntity.Model(tripName: data.1.tripName,
+                                                        note: data.1.note,
+                                                        budget: data.1.budget,
+                                                        departure: data.1.departure,
+                                                        homecoming: data.1.homecoming)
                 
                 switch owner.modalView.checkModalStatus() {
                 case .createNewCashBook:
                     // 가계부를 코어 데이터에 추가하는 로직
-                    CoreDataManager.shared.save(type: CashBookEntity.self, data: result)
+                    CoreDataManager.shared.save(type: CashBookEntity.self, data: cashBookData)
                     
                 case .editCashBook:
                     // 가계부를 코어 데이터에 업데이트 하는 로직
-                    CoreDataManager.shared.update(type: CashBookEntity.self, entityID: owner.modalView.getDataId(), data: result)
+                    CoreDataManager.shared.update(type: CashBookEntity.self, entityID: data.1.id, data: cashBookData)
                     
                 default: break
                 }
@@ -135,16 +135,23 @@ private extension ModalViewController {
                     alert.showAlert(on: vc, .alert)
                     return
                 }
-                // TODO: 수정요청(상경)
-                let result = MyCashBookEntity.Model(amount: 0.0, cashBookID: UUID(), category: "category", country: "country", expenseDate: Date(), note: "note", payment: true)
+                
+                let consumptionData = MyCashBookEntity.Model(amount: data.1.amount,
+                                                             cashBookID: data.1.cashBookID,
+                                                             category: data.1.category,
+                                                             country: data.1.country,
+                                                             expenseDate: data.1.expenseDate,
+                                                             note: data.1.note,
+                                                             payment: data.1.payment)
                 
                 switch owner.modalView.checkModalStatus() {
                 case .createNewConsumption:
                     // 지출내역을 코어 데이터에 추가하는 로직
-                    CoreDataManager.shared.save(type: MyCashBookEntity.self, data: result)
+                    CoreDataManager.shared.save(type: MyCashBookEntity.self, data: consumptionData)
+                    print(data.1.cashBookID, data.1.expenseDate)
                 case .editConsumption:
                     // 지출내역을 코어 데이터에 업데이트 하는 로직
-                    CoreDataManager.shared.update(type: MyCashBookEntity.self, entityID: owner.modalView.getDataId(), data: result)
+                    CoreDataManager.shared.update(type: MyCashBookEntity.self, entityID: data.1.id, data: consumptionData)
                     
                 default: break
                 }

--- a/TripLog/TripLog/Feat-Stone/View/TodayView/TodayVIewController.swift
+++ b/TripLog/TripLog/Feat-Stone/View/TodayView/TodayVIewController.swift
@@ -74,7 +74,8 @@ class TodayViewController: UIViewController {
     }
 
     @objc private func presentExpenseAddModal() {
-        ModalViewManager.showModal(on: self, state: .createNewConsumption)
+        // TODO: 가계부ID를 받아오고 날짜를 지정하는 로직 추가 요청(석준)
+        ModalViewManager.showModal(on: self, state: .createNewConsumption(cashBookID: UUID(), date: Date()))
             .subscribe(onNext: { [weak self] in
                 guard let self = self else { return }
 


### PR DESCRIPTION
이슈 번호: close #77 

## 요약
- 코어데이터 엔티티 모델의 형식에 맞도록 로직을 수정했습니다.
- 새로운 지출 내역을 추가할 때, 모달뷰에 가계부ID와 날짜 정보를 주입하도록 바꿨습니다.

## 작업 상세 내용
`ModalViewState`에서 새로운 지출 내역을 추가하는 케이스에 연관값을 추가하여 새로운 지출 내역을 만들 경우 가계부 ID와 지출 날짜를 주입해주도록 변경하였습니다.
```swift
case createNewConsumption(cashBookID: UUID, date: Date)
```
또, 기존에 `getDataID()`, `checkModalStatus()`같이 `internal`한 메소드들을 모두 `private`로 바꾸었으며, 대신 Rx 이벤트로 함께 방출하도록 로직을 수정하였습니다. (모달뷰의 로직 은닉 고도화)

추가로, 통화기호를 설정하는 메소드와 추출하는 메소드의 수정도 진행하여 예상하는 대로 동작하는지 동작 테스트도 진행하였습니다.

## 리뷰어 공유사항
@dnwn1211 님이 작업하신 파트 중, 오늘 지출내역에서 모달뷰를 호출하는 로직의 수정이 필요합니다.
기존에는 그냥 호출해도 됐지만, 이제는 가계부ID와 날짜 데이터를 주입해 주어야 하기 때문에 이 부분의 로직이 필요합니다.
```swift
    @objc private func presentExpenseAddModal() {
        ModalViewManager.showModal(on: self, state: .createNewConsumption)
        // TODO: 가계부ID를 받아오고 날짜를 지정하는 로직 추가 요청(석준)
        ModalViewManager.showModal(on: self, state: .createNewConsumption(cashBookID: UUID(), date: Date()))
```
참고하여 로직 수정 부탁드립니다.

## 스크린샷(선택)

| 특정 가계부에 지출 목록을 추가했을 때 |
| :-: |
| 상단: 가계부 데이터, 하단: 지출 목록 데이터 |
| ![스크린샷 2025-02-05 11 47 52](https://github.com/user-attachments/assets/3873513c-0175-46d7-984f-89e9443f091e) |
| 저장되는 데이터 형식 예시 |
| ![스크린샷 2025-02-05 11 55 42](https://github.com/user-attachments/assets/f77c6662-89c9-4c4b-8d8d-1d7d0fdffafc) |

| 특정 가계부의 지출 목록을 업데이트 했을 때 |
| :-: |
| ![스크린샷 2025-02-05 12 06 19](https://github.com/user-attachments/assets/8533a4bb-b190-447f-83e1-53be8b5097bf) |

업데이트의 경우, `MockMyCashBookModel`에서 `id`를 기본 값으로 생성하고 있기 때문에 id가 새로 생성되지만, 업데이트를 할 때는 모달뷰에 주입되었던 지출목록의 id를 사용하기 때문에 업데이트 로직이 정상적으로 이루어집니다.