### PR TITLE
♻️[refactor] 캘린더 헤더 날짜 변경 기능 리팩토링

### DIFF
--- a/TripLog/TripLog/Feat-Jamong/View/CalendarExpenseView/CalendarExpenseCell.swift
+++ b/TripLog/TripLog/Feat-Jamong/View/CalendarExpenseView/CalendarExpenseCell.swift
@@ -96,28 +96,17 @@ final class CalendarExpenseCell: UITableViewCell {
     /// - Parameter item: 표시할 지출 항목 데이터
     /// - Note: 외화 금액은 통화 종류에 따라 다른 형식으로 표시
     ///   (JPY, CNY는 정수로, 다른 통화는 소수점 포함)
-    func configure(with item: ExpenseItem) {
-        titleLabel.text = item.title
+    func configure(with model: MockMyCashBookModel) {
+        titleLabel.text = model.note
         
-        if let foreignAmount = item.foreignAmount {
-            let numberFormatter = NumberFormatter()
-            numberFormatter.numberStyle = .decimal
-            
-            if let formattedAmount = numberFormatter.string(from: NSNumber(value: foreignAmount)) {
-                // JPY와 CNY는 소수점 없이 정수로 표시
-                if item.currencyType == .jpy || item.currencyType == .cny {
-                    let intAmount = Int(foreignAmount)
-                    foreignAmountLabel.text = "\(item.currencyType.symbol) \(intAmount)"
-                } else {
-                    foreignAmountLabel.text = "\(item.currencyType.symbol) \(formattedAmount)"
-                }
-            }
-        } else {
-            foreignAmountLabel.text = nil
-        }
+        let numberFormatter = NumberFormatter()
+        numberFormatter.numberStyle = .decimal
+        // 변경 예정 model.country -> Symbol
+        foreignAmountLabel.text = "\(model.country) \(Int(model.amount).formatted())"
+        categoryLabel.text = "\(model.category)/\(model.payment ? "카드" : "현금")"
         
-        categoryLabel.text = "\(item.category) / \(item.paymentMethod)"
-        wonAmountLabel.text = "\(Int(item.wonAmount).formatted())원"
+        // 한화로 변경하는 로직이 필요함 한화 * 환율데이트 수정필요
+        wonAmountLabel.text = "\(Int(model.amount).formatted())원"
     }
     
     /// 셀이 재사용될 때 모든 상태를 초기화

--- a/TripLog/TripLog/Feat-Jamong/View/CalendarExpenseView/CalendarExpenseView.swift
+++ b/TripLog/TripLog/Feat-Jamong/View/CalendarExpenseView/CalendarExpenseView.swift
@@ -35,12 +35,11 @@ final class CalendarExpenseView: UIView {
         $0.font = .SCDream(size: .body, weight: .medium)
         $0.textColor = UIColor.CustomColors.Text.textSecondary
         $0.textAlignment = .center
-        $0.isHidden = true
     }
 
     // MARK: - Properties
     /// 현재 표시중인 지출 항목 배열
-    private var expenses: [ExpenseItem] = []
+    private var expenses: [MockMyCashBookModel] = []
     
     // MARK: - Initialization
     override init(frame: CGRect) {
@@ -94,9 +93,9 @@ final class CalendarExpenseView: UIView {
     ///   - date: 선택된 날짜
     ///   - expenses: 해당 날짜의 지출 항목 배열
     ///   - balance: 현재 잔액
-    func configure(date: Date, expenses: [ExpenseItem], balance: Int) {
+    func configure(date: Date, expenses: [MockMyCashBookModel], balance: Int) {
         self.expenses = expenses
-        let totalExpense = Int(expenses.reduce(0) { $0 + $1.wonAmount })
+        let totalExpense = Int(expenses.reduce(0) { $0 + $1.amount })
         headerView.configure(date: date, expense: totalExpense, balance: balance)
         
         // 데이터 유무에 따라 빈 상태 표시

--- a/TripLog/TripLog/Feat-Jamong/View/CalendarView/CalendarCustomCell.swift
+++ b/TripLog/TripLog/Feat-Jamong/View/CalendarView/CalendarCustomCell.swift
@@ -24,7 +24,7 @@ class CalendarCustomCell: FSCalendarCell {
     
     /// 해당 일자 지출 금액 라벨
     public let expenseLabel = UILabel().then {
-        $0.font = .SCDream(size: .subcaption, weight: .medium)
+        $0.font = .SCDream(size: .caption, weight: .medium)
         $0.textAlignment = .center
         $0.textColor = .red
         $0.adjustsFontSizeToFitWidth = true

--- a/TripLog/TripLog/Feat-Jamong/View/CalendarView/CalendarCustomHeaderView.swift
+++ b/TripLog/TripLog/Feat-Jamong/View/CalendarView/CalendarCustomHeaderView.swift
@@ -26,30 +26,16 @@ class CalendarCustomHeaderView: UIView {
     }
     
     /// 이전 달로 이동하는 버튼
-    private let previousButton = UIButton(type: .system).then {
+    fileprivate let previousButton = UIButton(type: .system).then {
         $0.setImage(UIImage(systemName: "chevron.left"), for: .normal)
         $0.tintColor = UIColor.CustomColors.Text.textPrimary
     }
     
     /// 다음 달로 이동하는 버튼
-    private let nextButton = UIButton(type: .system).then {
+    fileprivate let nextButton = UIButton(type: .system).then {
         $0.setImage(UIImage(systemName: "chevron.right"), for: .normal)
         $0.tintColor = UIColor.CustomColors.Text.textPrimary
     }
-    
-    // MARK: - Properties
-    var viewModel: CalendarViewModel? {
-        didSet {
-            bindViewModel()
-        }
-    }
-    
-    /// 연결된 FSCalendar 인스턴스
-    /// - weak 참조를 통해 순환 참조 방지
-    weak var calendar: FSCalendar?
-    
-    /// RxSwift 리소스 정리를 위한 DisposeBag
-    private var disposeBag = DisposeBag()
     
     // MARK: - Initialization
     override init(frame: CGRect) {
@@ -90,29 +76,20 @@ class CalendarCustomHeaderView: UIView {
         }
     }
     
-    // MARK: - UI Setup
-    private func bindViewModel() {
-        guard let viewModel = viewModel else { return }
-        
-        let input = CalendarViewModel.Input(
-            selectedDate: viewModel.currentPageRelay.asObservable(),
-            previousButtonTapped: previousButton.rx.tap.asObservable(),
-            nextButtonTapped: nextButton.rx.tap.asObservable()
-        )
-        
-        let output = viewModel.transform(input: input)
-
-        output.title
-            .drive(titleLabel.rx.text)
-            .disposed(by: disposeBag)
-
-        output.updatedDate
-            .drive(onNext: { [weak self] date in
-                guard let self = self else { return }
-                self.viewModel?.currentPageRelay.accept(date)
-                self.calendar?.setCurrentPage(date, animated: true)
-                self.calendar?.reloadData()
-            })
-            .disposed(by: disposeBag)
+    func updateTitle(date: Date) {
+        var formatter = DateFormatter()
+        formatter.dateFormat = "yyyy년 M월"
+        titleLabel.text = formatter.string(from: date)
     }
 }
+
+extension Reactive where Base: CalendarCustomHeaderView {
+    var previousButtonTapped : Observable<Void> {
+        base.previousButton.rx.tap.asObservable()
+    }
+    
+    var nextButtonTapped: Observable<Void> {
+        base.nextButton.rx.tap.asObservable()
+    }
+}
+

--- a/TripLog/TripLog/Feat-Jamong/View/CalendarView/CalendarView.swift
+++ b/TripLog/TripLog/Feat-Jamong/View/CalendarView/CalendarView.swift
@@ -107,6 +107,10 @@ final class CalendarView: UIView {
         }
         calendar.reloadData()
     }
+    
+    func updatePageLoad(date: Date) {
+        calendar.setCurrentPage(date, animated: true)
+    }
 }
 
 // MARK: - Extension for Setup Methods

--- a/TripLog/TripLog/Feat-Jamong/ViewModel/CalendarViewModel.swift
+++ b/TripLog/TripLog/Feat-Jamong/ViewModel/CalendarViewModel.swift
@@ -16,51 +16,93 @@ import FSCalendar
 class CalendarViewModel: ViewModelType {
     // MARK: - Input & Output
     struct Input {
-        let selectedDate: Observable<Date>
+        let selectedDate: BehaviorRelay<Date>
         let previousButtonTapped: Observable<Void>
         let nextButtonTapped: Observable<Void>
     }
     
     struct Output {
-        let title: Driver<String>
-        let updatedDate: Driver<Date>
+        let updatedDate: BehaviorRelay<Date>
     }
     
     // MARK: - Properties
     let disposeBag = DisposeBag()
     
-    // 현재 페이지를 저장하는 Relay
-    let currentPageRelay = BehaviorRelay<Date>(value: Date())
+    // 지출 데이터를 저장
+    private var expenseData: [Date: [MockMyCashBookModel]] = [:]
     
-    // MARK: - Transform Method
+    // 선택된 날짜의 지출 데이터를 방출하는 Observable
+    let selectedDateExpenses = PublishSubject<[MockMyCashBookModel]>()
+    
+    // 현재 페이지를 저장하는 Relay
+    private let currentPageRelay = BehaviorRelay<Date>(value: Date())
+    
+    // MARK: - Method
+    // expensesData 접근가능 메서드
+    func expensesForDate(_ date: Date) -> [MockMyCashBookModel] {
+        return expenseData[date] ?? []
+    }
+    
+    /// UserDefaults에서 지출 데이터를 로드하여 expenseData에 저장하는 메서드
+    func loadExpenseData() {
+
+    }
+    
+    /// 선택된 날짜의 총 지출 금액을 계산하는 메서드
+    /// - Parameter date: 총 지출 금액을 계산하는 날짜
+    /// - Returns: 해당 날짜의 총 지출 금액
+    func totalExpense(for date: Date) -> Double {
+        let expenses = expenseData[date] ?? []
+        return expenses.reduce(0) { $0 + $1.amount }
+    }
+    
+    /// ViewModel의 Input을 Output으로 변환하는 메서드
+    /// - Parameter input: ViewModel의 Input
+    /// - Returns: ViewModel의 Output
     func transform(input: Input) -> Output {
-        let dateFormatter = DateFormatter()
-        dateFormatter.dateFormat = "yyyy년 M월"
+        input.selectedDate
+            .asDriver(onErrorDriveWith: .empty())
+            .drive{ [weak self] date in
+                guard let self else { return }
+                self.currentPageRelay.accept(date) }
+            .disposed(by: disposeBag)
         
-        let title = input.selectedDate
-            .map { dateFormatter.string(from: $0) }
-            .asDriver(onErrorJustReturn: "")
+        input.previousButtonTapped
+            .map { [weak self] _ -> Date in
+                guard let currentDate = self?.currentPageRelay.value,
+                      let date = self?.previousMonth(from: currentDate) else { return Date() }
+                return date }
+            .asDriver(onErrorDriveWith: .empty())
+            .drive{ [weak self] date in
+                guard let self else { return }
+                self.currentPageRelay.accept(date) }
+            .disposed(by: disposeBag)
         
-        let previousDate = input.previousButtonTapped
-            .withLatestFrom(input.selectedDate)
-            .map { self.previousMonth(from: $0) }
+        input.nextButtonTapped
+            .map { [weak self] _ -> Date in
+                guard let currentDate = self?.currentPageRelay.value,
+                      let date = self?.nextMonth(from: currentDate) else { return Date() }
+                return date }
+            .asDriver(onErrorDriveWith: .empty())
+            .drive{ [weak self] date in
+                guard let self else { return }
+                self.currentPageRelay.accept(date) }
+            .disposed(by: disposeBag)
         
-        let nextDate = input.nextButtonTapped
-            .withLatestFrom(input.selectedDate)
-            .map { self.nextMonth(from: $0) }
-        
-        let updatedDate = Observable.merge(previousDate, nextDate)
-            .do(onNext: { self.currentPageRelay.accept($0) })
-            .asDriver(onErrorJustReturn: Date())
-        
-        return Output(title: title, updatedDate: updatedDate)
+        return Output(updatedDate: self.currentPageRelay)
     }
     
     // MARK: - Helper Methods
+    /// 현재 날짜로부터 이전 달의 날짜를 반환하는 메서드
+    /// - Parameter date: 현재 날짜
+    /// - Returns: 이전 달의 날짜
     private func previousMonth(from date: Date) -> Date {
         return Calendar.current.date(byAdding: .month, value: -1, to: date) ?? date
     }
     
+    /// 현재 날짜로부터 다음 달의 날짜를 반환하는 메서드
+    /// - Parameter date: 현재 날짜
+    /// - Returns: 다음 달의 날짜
     private func nextMonth(from date: Date) -> Date {
         return Calendar.current.date(byAdding: .month, value: 1, to: date) ?? date
     }


### PR DESCRIPTION
이슈 번호: #39 

## 요약
캘린더와 지출목록의 로직이 꼬여있어 코드를 다시 짜게됨.

현재 캘린더 커스텀 헤더뷰와 캘린더 뷰의 날짜 이동 및 이벤트 셀 클릭에 대한 반응 로직만 처리 했으며

그 외에 코드는 삭제함

## 작업 상세 내용
- 필요없는 로직 삭제
- View에서의 비즈니스 로직을 ViewModel로 옮김

## 리뷰어 공유사항
- 해당 이슈에 만족하지 않지만 각 뷰 연결후 테스트를 위해 풀리퀘스트 요청합니다.

## 스크린샷(선택
![Simulator Screenshot - iPhone 16 - 2025-02-04 at 16 32 19](https://github.com/user-attachments/assets/2aa75272-7781-4930-827e-70d52218f81d)
![Simulator Screenshot - iPhone 16 - 2025-02-04 at 16 32 17](https://github.com/user-attachments/assets/59ca7594-7288-430f-93d0-cba40513e8fd)
![Simulator Screenshot - iPhone 16 - 2025-02-05 at 18 17 24](https://github.com/user-attachments/assets/4fea6eb8-155f-4449-8f01-3b40a1a55bf4)
![Simulator Screenshot - iPhone 16 - 2025-02-05 at 18 17 16](https://github.com/user-attachments/assets/3a00c7d8-e3db-46a2-8718-c5b907e995eb)
