### PR TITLE
[Fix] 가계부 리스트에 추가하기 셀 버그 수정

### DIFF
--- a/TripLog/TripLog/Feat-Jeff/CashBookList/Service/UpdateTabBarItem.swift
+++ b/TripLog/TripLog/Feat-Jeff/CashBookList/Service/UpdateTabBarItem.swift
@@ -8,7 +8,7 @@ import UIKit
 
 extension UIButton {
     
-    /// 기존의 cofig로 설정한 데이터를 새로운 config 값으로 변경하는 메서드
+    /// 기존의 config로 설정한 데이터를 새로운 config 값으로 변경하는 메서드
     /// inout을 활용해 파라미터를 직접 내부에서 UIButton.Configuration(값)을 수정
     /// 수정된 데이터로 UIButton.Configuration에 반영
     func updateConfiguration(_ update: (inout UIButton.Configuration) -> Void) {

--- a/TripLog/TripLog/Feat-Jeff/CashBookList/View/AddCellView.swift
+++ b/TripLog/TripLog/Feat-Jeff/CashBookList/View/AddCellView.swift
@@ -64,4 +64,5 @@ private extension AddCellView {
             $0.height.equalTo(152)
         }
     }
+    
 }

--- a/TripLog/TripLog/Feat-Jeff/CashBookList/View/AddCellView.swift
+++ b/TripLog/TripLog/Feat-Jeff/CashBookList/View/AddCellView.swift
@@ -12,7 +12,7 @@ final class AddCellView: UIView {
     
     private let addNameLabel = UILabel().then {
         $0.text = "여행 추가하기"
-        $0.font = UIFont.SCDream(size: .headline, weight: .medium)
+        $0.font = UIFont.SCDream(size: .headline, weight: .bold)
         $0.textColor = .Dark.base
         $0.numberOfLines = 1
         $0.textAlignment = .left

--- a/TripLog/TripLog/Feat-Jeff/CashBookList/View/CashBookListViewController.swift
+++ b/TripLog/TripLog/Feat-Jeff/CashBookList/View/CashBookListViewController.swift
@@ -82,6 +82,7 @@ final class CashBookListViewController: UIViewController {
         super.traitCollectionDidChange(previousTraitCollection)
         if traitCollection.hasDifferentColorAppearance(comparedTo: previousTraitCollection) {
     
+            listCollectionView.backgroundColor = UIColor.CustomColors.Background.background
             addCellView.applyBoxStyle()
             
         }

--- a/TripLog/TripLog/Feat-Jeff/CashBookList/View/CashBookListViewController.swift
+++ b/TripLog/TripLog/Feat-Jeff/CashBookList/View/CashBookListViewController.swift
@@ -172,13 +172,26 @@ private extension CashBookListViewController {
             .bind(to: addButtonTapped)
             .disposed(by: disposeBag)
         
-        // 선택된 셀 동작처리(추후 구현)
+        // 선택된 셀의 오늘 지출화면으로 이동
         listCollectionView.rx.modelSelected(MockCashBookModel.self)
-            .subscribe(onNext: { selectedItem in
-                print("노트 : \(selectedItem.note), 예산 : \(selectedItem.budget) ")
-                self.navigationController?.pushViewController(TopViewController(), animated: true)
+            .subscribe(onNext: { [weak self] selectedItem in
+                guard let self = self else { return }
+                let data = self.getData(selectedItem)
+                self.navigationController?.pushViewController(TopViewController(cashBook: data), animated: true)
             })
             .disposed(by: disposeBag)
+    }
+    
+    /// 셀에서 선택된 데이터를 Model에 넣어서 전달
+    func getData(_ selectedData: ControlEvent<MockCashBookModel>.Element) -> MockCashBookModel {
+        let data = MockCashBookModel(
+            id: selectedData.id,
+            tripName: selectedData.tripName,
+            note: selectedData.note,
+            budget: selectedData.budget,
+            departure: selectedData.departure,
+            homecoming: selectedData.homecoming)
+        return data
     }
     
     /// CollectionView Layout

--- a/TripLog/TripLog/Feat-Jeff/CashBookList/View/CashBookListViewController.swift
+++ b/TripLog/TripLog/Feat-Jeff/CashBookList/View/CashBookListViewController.swift
@@ -78,13 +78,13 @@ final class CashBookListViewController: UIViewController {
         viewWillAppearSubject.onNext(())
     }
     
+    // 앱의 라이트모드/다크모드가 변경 되었을 때 이를 감지하여 CALayer의 컬러를 재정의 해주는 메소드
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
         if traitCollection.hasDifferentColorAppearance(comparedTo: previousTraitCollection) {
-    
+            
             listCollectionView.backgroundColor = UIColor.CustomColors.Background.background
             addCellView.applyBoxStyle()
-            
         }
     }
     

--- a/TripLog/TripLog/Feat-Jeff/CashBookList/View/ListCollectionViewCell.swift
+++ b/TripLog/TripLog/Feat-Jeff/CashBookList/View/ListCollectionViewCell.swift
@@ -66,13 +66,20 @@ final class ListCollectionViewCell: UICollectionViewCell {
         fatalError("init(coder:) has not been implemented")
     }
     
+    // 앱의 라이트모드/다크모드가 변경 되었을 때 이를 감지하여 CALayer의 컬러를 재정의 해주는 메소드
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
         if traitCollection.hasDifferentColorAppearance(comparedTo: previousTraitCollection) {
-    
-            contentView.applyBoxStyle()
             
+            contentView.applyBoxStyle()
         }
+    }
+    
+    /// 셀이 재사용될 때 모든 상태를 초기화
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        
+        resetCell()
     }
     
 }
@@ -124,6 +131,14 @@ private extension ListCollectionViewCell {
         periodLabel.snp.makeConstraints {
             $0.height.equalTo(20)
         }
+    }
+    
+    /// 셀 재사용 시 리셋 메서드
+    func resetCell() {
+        tripNameLabel.text = nil
+        noteLabel.text = nil
+        budgetLabel.text = nil
+        periodLabel.text = nil
     }
     
 }

--- a/TripLog/TripLog/Feat-Jeff/CashBookList/ViewModel/CashBookListViewModel.swift
+++ b/TripLog/TripLog/Feat-Jeff/CashBookList/ViewModel/CashBookListViewModel.swift
@@ -9,7 +9,7 @@ import CoreData
 import RxSwift
 import RxCocoa
 
-class CashBookListViewModel: NSObject, ViewModelType, NSFetchedResultsControllerDelegate {
+final class CashBookListViewModel: NSObject, ViewModelType, NSFetchedResultsControllerDelegate {
     
     struct Input {
         let callViewWillAppear: Observable<Void>

--- a/TripLog/TripLog/Feat-Jeff/CashBookList/ViewModel/CashBookListViewModel.swift
+++ b/TripLog/TripLog/Feat-Jeff/CashBookList/ViewModel/CashBookListViewModel.swift
@@ -57,7 +57,7 @@ class CashBookListViewModel: NSObject, ViewModelType, NSFetchedResultsController
         let fetchedData = fetchedResultsController.fetchedObjects ?? []
         
         // 패치 결과로 업데이트
-        let sectionData = [
+        let sectionData: [SectionOfListCellData] = fetchedData.isEmpty ? [] : [
             SectionOfListCellData(
                 id: UUID(), // 섹션 구분
                 items: fetchedData.map { entity in
@@ -103,7 +103,6 @@ class CashBookListViewModel: NSObject, ViewModelType, NSFetchedResultsController
             .asObservable()
         
         let addCellViewHidden = updatedData
-            .debug()
             .map { $0.isEmpty ? 1.0 : 0.0 }
             .asDriver(onErrorJustReturn: 0.0)
         

--- a/TripLog/TripLog/Feat-Jeff/CustomTabBar/View/CustomTabBarController.swift
+++ b/TripLog/TripLog/Feat-Jeff/CustomTabBar/View/CustomTabBarController.swift
@@ -30,15 +30,14 @@ final class CustomTabBarController: UIViewController {
         bind()
     }
     
+    // 앱의 라이트모드/다크모드가 변경 되었을 때 이를 감지하여 CALayer의 컬러를 재정의 해주는 메소드
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
         if traitCollection.hasDifferentColorAppearance(comparedTo: previousTraitCollection) {
             
             customTabBar.applyTabBarStyle()
-            
         }
     }
-    
     
 }
 
@@ -139,11 +138,11 @@ private extension CustomTabBarController {
     }
     
     /// 선택한 탭바의 화면으로 전환 (애니메이션 추가)
-      func switchToViewController(_ viewController: UIViewController) {
+    func switchToViewController(_ viewController: UIViewController) {
         UIView.transition(with: view, duration: 0.3, options: .transitionCrossDissolve, animations: {
             self.view.bringSubviewToFront(viewController.view)
             self.view.bringSubviewToFront(self.customTabBar) // 탭바가 항상 위에 있도록 추가
         }, completion: nil)
-      }
+    }
     
 }

--- a/TripLog/TripLog/Feat-Jeff/CustomTabBar/View/CustomTabBarController.swift
+++ b/TripLog/TripLog/Feat-Jeff/CustomTabBar/View/CustomTabBarController.swift
@@ -85,7 +85,7 @@ private extension CustomTabBarController {
         
         customTabBar.snp.makeConstraints {
             $0.bottom.equalTo(view.safeAreaLayoutGuide.snp.bottom)
-            $0.leading.trailing.equalToSuperview().inset(-10)
+            $0.horizontalEdges.equalToSuperview()
             $0.height.equalTo(60)
         }
     }

--- a/TripLog/TripLog/Feat-Jeff/CustomTabBar/View/CustomTabBarView.swift
+++ b/TripLog/TripLog/Feat-Jeff/CustomTabBar/View/CustomTabBarView.swift
@@ -66,7 +66,7 @@ final class TabBarView: UIView {
 
     let tabBarAddButton = UIButton().then {
         $0.setImage(UIImage(systemName: "plus"), for: .normal)
-        $0.tintColor = UIColor.CustomColors.Border.plus
+        $0.tintColor = UIColor.CustomColors.Background.background
         $0.backgroundColor = UIColor.CustomColors.Accent.blue
     }
     

--- a/TripLog/TripLog/Feat-Jeff/CustomTabBar/View/CustomTabBarView.swift
+++ b/TripLog/TripLog/Feat-Jeff/CustomTabBar/View/CustomTabBarView.swift
@@ -21,7 +21,7 @@ final class TabBarView: UIView {
     let cashBookTapped = PublishRelay<Void>()
     let settingTapped = PublishRelay<Void>()
     let tabBarAddButtonTapped = PublishRelay<Void>()
-     
+    
     private var cashBookTabButton: UIButton = {
         var config = UIButton.Configuration.plain()
         // 배경색과 텍스트색 설정
@@ -40,7 +40,7 @@ final class TabBarView: UIView {
         
         let button = UIButton(configuration: config)
         
-       return button
+        return button
     }()
     
     private var settingTabButton: UIButton = {
@@ -61,9 +61,9 @@ final class TabBarView: UIView {
         
         let button = UIButton(configuration: config)
         
-       return button
+        return button
     }()
-
+    
     let tabBarAddButton = UIButton().then {
         $0.setImage(UIImage(systemName: "plus"), for: .normal)
         $0.tintColor = UIColor.CustomColors.Background.background
@@ -83,14 +83,15 @@ final class TabBarView: UIView {
         fatalError("init(coder:) has not been implemented")
     }
     
+    // 앱의 라이트모드/다크모드가 변경 되었을 때 이를 감지하여 CALayer의 컬러를 재정의 해주는 메소드
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
         if traitCollection.hasDifferentColorAppearance(comparedTo: previousTraitCollection) {
-    
-            tabBarAddButton.applyTabBarButtonStyle()
             
+            tabBarAddButton.applyTabBarButtonStyle()
         }
     }
+    
 }
 
 //MARK: - Private Method
@@ -154,6 +155,7 @@ private extension TabBarView {
             .bind(to: tabBarAddButtonTapped)
             .disposed(by: disposeBag)
     }
+    
 }
 
 //MARK: - Method
@@ -183,6 +185,7 @@ extension TabBarView {
             }
         }
     }
+    
 }
 
 

--- a/TripLog/TripLog/Source/Extension/UIViewStyle+Extension.swift
+++ b/TripLog/TripLog/Source/Extension/UIViewStyle+Extension.swift
@@ -178,7 +178,6 @@ extension UIView {
     
     /// TabBar Style
     func applyTabBarStyle() {
-        applyCornerRadius()
         applyTabBarShadow()
         applyBackgroundColor()
     }

--- a/TripLog/TripLog/Source/Extension/UIViewStyle+Extension.swift
+++ b/TripLog/TripLog/Source/Extension/UIViewStyle+Extension.swift
@@ -101,7 +101,7 @@ extension UIView {
         layer.shadowColor = darkModeCheck(UIColor.white.cgColor, UIColor.black.cgColor)
         layer.shadowOpacity = darkModeCheck(0.3, 0.1)
         layer.shadowRadius = 1.5
-        layer.shadowOffset = CGSize(width: 0, height: -2)
+        layer.shadowOffset = CGSize(width: 0, height: -3)
         layer.masksToBounds = false
     }
     


### PR DESCRIPTION
이슈 번호: #80 

## 요약
- 추가하기 버튼 셀이 적용이 안되는 부분 수정
- 탭바 하단에 흰색 실선(그림자)이 생기는 부분 수정
- 셀 전달 메서드 수정

## 작업 상세 내용
- 기존에 화면에 셀이 비어있는 경우 추가하기 버튼 셀이 적용이 안되던 부분 수정하였습니다.
- 다크모드에서 보이는 탭바 하단의 실선을 수정하였습니다.
- 가계부 리스트에서 셀을 선택 시 해당 셀의 데이터를 오늘지출 뷰로 전달하도록 수정하였습니다.

## 리뷰어 공유사항
석준님 파일이 아직 merge가 되지 않아서 테스트를 하실 경우 
TopViewController에서 아래의 코드를 추가해주시고 사용해 주시면 되겠습니다.
```swift 
// ✅ `context` 없이 UUID 및 개별 데이터만 받도록 수정
       init(cashBook: MockCashBookModel) {
           print(cashBook)
           super.init(nibName: nil, bundle: nil)
       }
    
    required init?(coder: NSCoder) {
        fatalError("init(coder:) has not been implemented")
    }
```

## 스크린샷(선택)

![Screen Recording 2025-02-06 at 3 17 27 PM](https://github.com/user-attachments/assets/e8641f95-4a87-4937-af36-53a7c9e0e537)
