### PR TITLE
[Refactor] 모달뷰 로직 수정

### DIFF
--- a/TripLog/TripLog/Feat-Crois/ModalViewController/Model/MockDataProtocol.swift
+++ b/TripLog/TripLog/Feat-Crois/ModalViewController/Model/MockDataProtocol.swift
@@ -1,0 +1,13 @@
+//
+//  MockDataProtocol.swift
+//  TripLog
+//
+//  Created by 장상경 on 2/9/25.
+//
+
+import Foundation
+
+protocol MockDataProtocol {}
+
+extension MockCashBookModel: MockDataProtocol {}
+extension MockMyCashBookModel: MockDataProtocol {}

--- a/TripLog/TripLog/Feat-Crois/ModalViewController/Model/ModalConsumptionData.swift
+++ b/TripLog/TripLog/Feat-Crois/ModalViewController/Model/ModalConsumptionData.swift
@@ -1,0 +1,15 @@
+//
+//  ModalConsumptionData.swift
+//  TripLog
+//
+//  Created by 장상경 on 2/9/25.
+//
+
+import Foundation
+
+/// 모달뷰에서 새 지출내역을 추가할 때 사용할 데이터 타입
+struct ModalConsumptionData {
+    let cashBookID: UUID
+    let date: Date
+    let exchangeRate: String
+}

--- a/TripLog/TripLog/Feat-Crois/ModalViewController/Model/ModalConsumptionData.swift
+++ b/TripLog/TripLog/Feat-Crois/ModalViewController/Model/ModalConsumptionData.swift
@@ -11,5 +11,5 @@ import Foundation
 struct ModalConsumptionData {
     let cashBookID: UUID
     let date: Date
-    let exchangeRate: String
+    let exchangeRate: CurrencyRate
 }

--- a/TripLog/TripLog/Feat-Crois/ModalViewController/Model/ModalViewState.swift
+++ b/TripLog/TripLog/Feat-Crois/ModalViewController/Model/ModalViewState.swift
@@ -12,7 +12,7 @@ enum ModalViewState {
     case createNewCashBook
     case editCashBook(data: MockCashBookModel) // 가계부 수정시 데이터 입력
     case createNewConsumption(data: ModalConsumptionData)
-    case editConsumption(data: MockMyCashBookModel) // 지출 내역 수정 시 데이터 입력
+    case editConsumption(data: MockMyCashBookModel, exchangeRate: CurrencyRate) // 지출 내역 수정 시 데이터 입력
     
     /// 각 상태에 따라 모달 뷰의 타이틀을 결정하는 프로퍼티
     var modalTitle: String {

--- a/TripLog/TripLog/Feat-Crois/ModalViewController/Model/ModalViewState.swift
+++ b/TripLog/TripLog/Feat-Crois/ModalViewController/Model/ModalViewState.swift
@@ -11,7 +11,7 @@ import Foundation
 enum ModalViewState {
     case createNewCashBook
     case editCashBook(data: MockCashBookModel) // 가계부 수정시 데이터 입력
-    case createNewConsumption(cashBookID: UUID, date: Date)
+    case createNewConsumption(data: ModalConsumptionData)
     case editConsumption(data: MockMyCashBookModel) // 지출 내역 수정 시 데이터 입력
     
     /// 각 상태에 따라 모달 뷰의 타이틀을 결정하는 프로퍼티

--- a/TripLog/TripLog/Feat-Crois/ModalViewController/View/ModalView.swift
+++ b/TripLog/TripLog/Feat-Crois/ModalViewController/View/ModalView.swift
@@ -64,6 +64,7 @@ final class ModalView: UIView {
     private var cashBookID: UUID?
     private var consumptionID: UUID?
     private var expenseDate: Date?
+    private var exchangeRate: String?
     
     // MARK: - Initializer
     
@@ -248,14 +249,15 @@ private extension ModalView {
                     .disposed(by: disposeBag)
             }
             
-        case .createNewConsumption(cashBookID: let id, date: let date):
+        case .createNewConsumption(data: let data):
             if
                let secondSection = self.secondSection as? ModalTextField,
                let thirdSection = self.thirdSection as? ModalTextField,
                let forthSection = self.forthSection as? ModalAmountView
             {
-                self.cashBookID = id
-                self.expenseDate = date
+                self.cashBookID = data.cashBookID
+                self.expenseDate = data.date
+                self.exchangeRate = data.exchangeRate
                 
                 secondSection.rx.textFieldIsBlank
                     .bind(to: firstTextFieldIsBlank)

--- a/TripLog/TripLog/Feat-Crois/ModalViewController/View/ModalView.swift
+++ b/TripLog/TripLog/Feat-Crois/ModalViewController/View/ModalView.swift
@@ -14,7 +14,7 @@ import RxCocoa
 /// 모달 뷰 컨트롤러의 뷰로 쓰일 모달 뷰
 final class ModalView: UIView {
     typealias ModalCashBookData = (id: UUID, tripName: String, note: String, budget: Int,departure: String, homecoming: String, state: ModalViewState)
-    typealias ModalConsumptionData = (id: UUID, cashBookID: UUID, expenseDate: Date, payment: Bool, note: String, category: String, amount: Double, country: String, state: ModalViewState)
+    typealias ModalConsumptionData = (id: UUID, cashBookID: UUID, expenseDate: Date, payment: Bool, note: String, category: String, amount: Double, country: String, state: ModalViewState, exchangeRate: Double)
     
     // MARK: - Rx Properties
     
@@ -64,7 +64,7 @@ final class ModalView: UIView {
     private var cashBookID: UUID?
     private var consumptionID: UUID?
     private var expenseDate: Date?
-    private var exchangeRate: String?
+    private var exchangeRate: CurrencyRate?
     
     // MARK: - Initializer
     
@@ -193,6 +193,21 @@ private extension ModalView {
         return expenseDate
     }
     
+    /// 환율을 계산해서 원화로 반환하는 메소드
+    /// - Parameters:
+    ///   - country: 환율을 적용할 국가 통화코드
+    ///   - amount: 기준 원화
+    /// - Returns: 환율을 적용한 원화
+    func exchangeRateCalculation(_ country: String, _ amount: Double) -> Double {
+        guard
+            let currency = exchangeRate?.filter({ $0.curUnit == country }).first,
+            let rate = Double(currency.dealBasR ?? "")
+        else { return 0 }
+        
+        let result = amount / rate
+        return result
+    }
+    
     /// 모달뷰를 세팅하는 메소드
     func setupModal() {
         switch self.state {
@@ -272,7 +287,7 @@ private extension ModalView {
                     .disposed(by: disposeBag)
             }
             
-        case .editConsumption(data: let data):
+        case .editConsumption(data: let data, exchangeRate: let rate):
             if let firstSection = self.firstSection as? ModalSegmentView,
                let secondSection = self.secondSection as? ModalTextField,
                let thirdSection = self.thirdSection as? ModalTextField,
@@ -286,6 +301,7 @@ private extension ModalView {
                 self.cashBookID = data.cashBookID
                 self.consumptionID = data.id
                 self.expenseDate = data.expenseDate
+                self.exchangeRate = rate
                 
                 secondSection.rx.textFieldIsBlank
                     .bind(to: firstTextFieldIsBlank)
@@ -343,6 +359,8 @@ private extension ModalView {
                 let forth = forthSection as? ModalAmountView
             else { return nil }
             
+            let exchangeRate = exchangeRateCalculation(forth.currencyExtraction(), forth.amountExtraction())
+            
             let consumptionData = (getConsumptionID(),
                                    getCashBookID(),
                                    getExpenseDate(),
@@ -351,7 +369,8 @@ private extension ModalView {
                                    third.textFieldExtraction(),
                                    forth.amountExtraction(),
                                    forth.currencyExtraction(),
-                                   state)
+                                   state,
+                                   exchangeRate)
         
             return consumptionData
             
@@ -379,7 +398,7 @@ private extension ModalView {
             buttons.rx.activeButtondTapped
                 .map { [weak self] _ -> ModalView.ModalConsumptionData in
                     guard let data = self?.consumptionDataExtraction() else {
-                        return (UUID(), UUID(), Date(), false, "", "", 0, "", ModalViewState.createNewCashBook)
+                        return (UUID(), UUID(), Date(), false, "", "", 0, "", ModalViewState.createNewCashBook, 0)
                     }
                     
                     return data

--- a/TripLog/TripLog/Feat-Jeff/CashBookList/View/CashBookListViewController.swift
+++ b/TripLog/TripLog/Feat-Jeff/CashBookList/View/CashBookListViewController.swift
@@ -155,7 +155,8 @@ private extension CashBookListViewController {
             .asSignal(onErrorSignalWith: .empty())
             .withUnretained(self)
             .emit(onNext: { owner, _ in
-                ModalViewManager.showModal(on: owner, state: .createNewCashBook)
+                // TODO: 모달뷰 로직 추후 수정 요청(재훈)
+//                ModalViewManager.showModal(on: owner, state: .createNewCashBook)
             })
             .disposed(by: disposeBag)
         
@@ -249,7 +250,7 @@ private extension CashBookListViewController {
                         return
                     }
                     
-                    ModalViewManager.showModal(on: self, state: .editCashBook(data: data))
+//                    ModalViewManager.showModal(on: self, state: .editCashBook(data: data))
                     completion(true)
                 }
                 return UISwipeActionsConfiguration(actions: [editAction])

--- a/TripLog/TripLog/Feat-Jeff/CustomTabBar/View/CustomTabBarController.swift
+++ b/TripLog/TripLog/Feat-Jeff/CustomTabBar/View/CustomTabBarController.swift
@@ -128,13 +128,16 @@ private extension CustomTabBarController {
             .disposed(by: disposeBag)
         
         // 탭바의 추가하기 버튼 바인딩
+        // TODO: 데이터 임의 바인딩, 추후 수정 요청(재훈)
         customTabBar.tabBarAddButtonTapped
+            .flatMap {
+                return ModalViewManager.showModal(state: .createNewCashBook)
+                    .compactMap { $0 as? MockCashBookModel }
+            }
             .asSignal(onErrorSignalWith: .empty())
-            .withUnretained(self)
-            .emit(onNext: { owner, _ in
-                ModalViewManager.showModal(on: owner, state: .createNewCashBook)
-            })
-            .disposed(by: disposeBag)
+            .emit { data in
+                CoreDataManager.shared.save(type: CashBookEntity.self, data: data)
+            }.disposed(by: disposeBag)
     }
     
     /// 선택한 탭바의 화면으로 전환 (애니메이션 추가)

--- a/TripLog/TripLog/Feat-Stone/View/TodayView/TodayVIewController.swift
+++ b/TripLog/TripLog/Feat-Stone/View/TodayView/TodayVIewController.swift
@@ -198,7 +198,8 @@ class TodayViewController: UIViewController {
                     print("📌 self가 nil입니다.") // ✅ 메모리 해제 문제 확인
                     return .empty()
                 }
-                return ModalViewManager.showModal(on: self, state: .editConsumption(data: selectedExpense))
+                // TODO: 모달뷰 로직 추후 수정 요청(석준)
+                return ModalViewManager.showModal(state: .editConsumption(data: selectedExpense)).map { $0 }
             }
             .subscribe(onNext: { [weak self] in
                 guard let self = self else { return }
@@ -217,28 +218,30 @@ class TodayViewController: UIViewController {
     }
                            
     @objc private func presentExpenseAddModal() {
-        ModalViewManager.showModal(on: self, state: .createNewConsumption(cashBookID: self.cashBookID, date: Date()))
-            .subscribe(onNext: { [weak self] in
-                guard let self = self else { return }
-                print("📌 사용된 cashBookID: \(self.cashBookID)")
-                print("📌 저장된 날짜: \(Date())")
-
-                // ✅ 모달 닫힌 후 데이터 새로고침
-                self.viewModel.input.fetchTrigger.accept(self.cashBookID)
-            })
-            .disposed(by: disposeBag)
+        // TODO: 모달뷰 로직 추후 수정 요청(석준)
+//        ModalViewManager.showModal(on: self, state: .createNewConsumption(cashBookID: self.cashBookID, date: Date()))
+//            .subscribe(onNext: { [weak self] in
+//                guard let self = self else { return }
+//                print("📌 사용된 cashBookID: \(self.cashBookID)")
+//                print("📌 저장된 날짜: \(Date())")
+//
+//                // ✅ 모달 닫힌 후 데이터 새로고침
+//                self.viewModel.input.fetchTrigger.accept(self.cashBookID)
+//            })
+//            .disposed(by: disposeBag)
     }
     
     private func presentExpenseEditModal(data: MockMyCashBookModel) {
-        ModalViewManager.showModal(on: self, state: .editConsumption(data: data))
-            .subscribe(onNext: { [weak self] in
-                guard let self = self else { return }
-                print("📌 수정된 내역: \(data)")
-                
-                // ✅ 모달 닫힌 후 데이터 새로고침
-                self.viewModel.input.fetchTrigger.accept(self.cashBookID)
-            })
-            .disposed(by: disposeBag)
+        // TODO: 모달뷰 로직 추후 수정 요청(석준)
+//        ModalViewManager.showModal(on: self, state: .editConsumption(data: data))
+//            .subscribe(onNext: { [weak self] in
+//                guard let self = self else { return }
+//                print("📌 수정된 내역: \(data)")
+//                
+//                // ✅ 모달 닫힌 후 데이터 새로고침
+//                self.viewModel.input.fetchTrigger.accept(self.cashBookID)
+//            })
+//            .disposed(by: disposeBag)
     }
 
 }


### PR DESCRIPTION
이슈 번호: close #93 

## 요약
- 모달뷰의 state 리팩토링
- 모달뷰 Rx 로직 리팩토링
- 모달뷰 환율 계산 로직 추가
- 모달뷰 전체적인 역할 감소

## 작업 상세 내용
모달뷰를 통해 새로운 지출 항목을 추가할 때, 환율을 제대로 적용할 수 있도록 `ModalViewManager.showModal()`메소드를 수정했습니다.
```swift
static func showModal(state: ModalViewState) -> Observable<MockDataProtocol> {
        guard let view = AppHelpers.getTopViewController() else {
            return .error(NSError(domain: "No top view controller", code: -1))
        }
        
        let modalVC = ModalViewController(state: state)
        view.present(modalVC, animated: true)
        
        return Observable<MockDataProtocol>.merge(
            modalVC.rx.sendCashBookData.map { $0 as MockDataProtocol },
            modalVC.rx.sendConsumptionData.map { $0 as MockDataProtocol }
        )
}
```
이제는 파라미터로 `UIViewController`를 지정하지 않아도 되며,
return 타입이 기존 `Observable<Void>` 였던 것을 `Observable<MockDataProtocol>`로 수정하였습니다.

`MockDataProtocol`은 리팩토링을 하며 새로 추가한 프로토콜로,
아무런 기능이 정의되어 있지 않은 빈 프로토콜입니다.
이는 `MockCashBookModel`과 `MockMyCashBookModel`을 특정하기 위해 구현하였습니다.

또, 모달뷰의 state에서 지출내역을 추가하기 위해서는 `cashBookID`, `date`, `exchangeRate`라는 3가지 데이터 타입이 필요합니다.
지출 내역을 수정하고 싶을 때는 `MockMyCashBookModel`과 `exchangeRate`라는 2가지 데이터 타입이 필요합니다.

**이제 모달뷰는 내부 로직을 통해 코어데이터에 데이터를 직접 저장하지 않습니다.**

모달뷰는 내부 로직을 통해 사용자의 입력값을 `MockCashBookModel` 혹은 `MockMyCashBookModel` 타입으로 데이터를 가공한 후, RxBinding을 통해 `showModal(state:)`의 return 으로 가공한 데이터를 반환하게 됩니다.

때문에 이와 관련된 로직들의 수정이 요청되며, 사용 예시도 바뀌었습니다.
```swift
// 모달뷰 로직 사용 예시
customTabBar.tabBarAddButtonTapped
            .flatMap {
                return ModalViewManager.showModal(state: .createNewCashBook)
                    .compactMap { $0 as? MockCashBookModel }
            }
            .asSignal(onErrorSignalWith: .empty())
            .emit { data in
                CoreDataManager.shared.save(type: CashBookEntity.self, data: data)
            }.disposed(by: disposeBag)
```
위의 코드는 예시일 뿐, 본인이 편한 방식을 택해주시면 됩니다.
중요한 점은 `showModal(state:)`의 return 타입은 `MockDataProtocol` 타입으로 추상화 되어있기 때문에
반드시 `as?` 등을 통한 **타입캐스팅 후 사용이 가능**하다는 점입니다.

## 리뷰어 공유사항
모달뷰의 로직과 연관된 부분에 `// TODO:` 를 통해 메세지를 남겨두었으니
관련 작업자 분들은 내용 참고하시어 로직의 수정을 부탁드립니다.

## 스크린샷(선택)
#### 로직 변경 후 저장이 잘 이루어지는지 테스트
![무제](https://github.com/user-attachments/assets/96ae028b-fa29-49a6-9165-a590b82804eb)

