### PR TITLE
[Feat] 캘린더와 CoreData 연결

### DIFF
--- a/TripLog/TripLog/Feat-Jamong/View/CalendarViewController.swift
+++ b/TripLog/TripLog/Feat-Jamong/View/CalendarViewController.swift
@@ -56,7 +56,20 @@ final class CalendarViewController: UIViewController {
         $0.layoutMargins = UIEdgeInsets(top: 0, left: 10, bottom: 10, right: 10)
     }
     
-    private let calendarViewModel = CalendarViewModel()
+    private let calendarViewModel : CalendarViewModel
+    
+    // MARK: - Initalization
+    
+    /// 가계부 ID 받아오기
+    /// - Parameter cashBook: 가계부 ID
+    init(cashBook: UUID) {
+        self.calendarViewModel = CalendarViewModel(cashBookID: cashBook)
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
     
     // MARK: - Properties
     /// 날짜별 지출 데이터를 저장하는 딕셔너리

--- a/TripLog/TripLog/Feat-Jamong/View/CalendarViewController.swift
+++ b/TripLog/TripLog/Feat-Jamong/View/CalendarViewController.swift
@@ -222,11 +222,20 @@ extension CalendarViewController: FSCalendarDelegate, FSCalendarDataSource {
         return cell
     }
     
+    /// 셀의 날짜 레이블을 설정하는 메서드
+    /// - Parameters:
+    ///   - cell: 설정할 캘린더 커스텀 셀
+    ///   - date: 표시할 날짜
     private func configureCellDate(_ cell: CalendarCustomCell, for date: Date) {
         let day = Calendar.current.component(.day, from: date)
         cell.titleLabel.text = "\(day)"
     }
     
+    
+    /// 셀의 지출금액 레이블을 설정하는 메서드
+    /// - Parameters:
+    ///   - cell: 설정할 캘린더 커스텀 셀
+    ///   - date: 지출금액을 계산할 날짜
     private func configureCellExpense(_ cell: CalendarCustomCell, for date: Date) {
         let totalExpense = calendarViewModel.totalExpense(for: date)
         if totalExpense > 0 {
@@ -238,6 +247,11 @@ extension CalendarViewController: FSCalendarDelegate, FSCalendarDataSource {
         }
     }
     
+    /// 셀의 전체적인 외관을 설정하는 메서드
+    /// - Parameters:
+    ///   - cell: 설정할 캘린더 커스텀 셀
+    ///   - date: 셀에 표시될 날짜
+    ///   - calendar: 현재 FSCalendar 인스턴스
     private func configureCellAppearance(_ cell: CalendarCustomCell, for date: Date, in calendar: FSCalendar) {
         if calendar.selectedDate == date {
             configureSelectedCell(cell)
@@ -246,6 +260,8 @@ extension CalendarViewController: FSCalendarDelegate, FSCalendarDataSource {
         }
     }
     
+    /// 선택된 셀의 스타일을 설정하는 메서드
+    /// - Parameter cell: 스타일을 적용할 셀
     private func configureSelectedCell(_ cell: CalendarCustomCell) {
         cell.contentView.backgroundColor = .systemBlue
         cell.contentView.layer.cornerRadius = 10
@@ -254,6 +270,10 @@ extension CalendarViewController: FSCalendarDelegate, FSCalendarDataSource {
         cell.expenseLabel.textColor = .white
     }
     
+    /// 선택되지 않은 셀의 스타일을 설정하는 메서드
+    /// - Parameters:
+    ///   - cell: 스타일을 적용할 셀
+    ///   - date: 셀의 날짜
     private func configureUnselectedCell(_ cell: CalendarCustomCell, for date: Date) {
         let isToday = Calendar.current.isDateInToday(date)
         cell.titleLabel.textColor = isToday ? .systemBlue : UIColor.CustomColors.Text.textPrimary

--- a/TripLog/TripLog/Feat-Jamong/ViewModel/CalendarViewModel.swift
+++ b/TripLog/TripLog/Feat-Jamong/ViewModel/CalendarViewModel.swift
@@ -13,7 +13,7 @@ import SnapKit
 import FSCalendar
 
 // 1. CashBookId를 받아오는 로직 [완료]
-// 2. CoreData와 연결하여 CashBookId를 통해 데이터를 가져오고 삭제, 수정할 수 있는 로직
+// 2. CoreData와 연결하여 CashBookId를 통해 데이터를 가져오고 삭제, 수정할 수 있는 로직 [완료]
 // 3. ViewController에 Date에 따른 ExpenseLabel 보내주는 로직
 // 4. 캘린더뷰 - 지출목록의 Date에 따른 데이터 연결해주는 로직
 // 5. 지출목록의 추가하고 삭제할때 바인딩하는 로직
@@ -27,6 +27,7 @@ class CalendarViewModel: ViewModelType {
     
     struct Output {
         let updatedDate: BehaviorRelay<Date>
+        let expenses: BehaviorRelay<[MockMyCashBookModel]>
     }
     
     // MARK: - Properties
@@ -36,10 +37,7 @@ class CalendarViewModel: ViewModelType {
     private let cashBookID: UUID
     
     // 지출 데이터를 저장
-    private var expenseData: [Date: [MockMyCashBookModel]] = [:]
-    
-    // 선택된 날짜의 지출 데이터를 방출하는 Observable
-    let selectedDateExpenses = PublishSubject<[MockMyCashBookModel]>()
+    private let expenseRelay = BehaviorRelay<[MockMyCashBookModel]>(value: [])
     
     // 현재 페이지를 저장하는 Relay
     private let currentPageRelay = BehaviorRelay<Date>(value: Date())
@@ -48,28 +46,11 @@ class CalendarViewModel: ViewModelType {
     // MARK: - Initalization
     init(cashBookID: UUID) {
         self.cashBookID = cashBookID
+        loadExpenseData()
     }
     
     
     // MARK: - Method
-    // expensesData 접근가능 메서드
-    func expensesForDate(_ date: Date) -> [MockMyCashBookModel] {
-        return expenseData[date] ?? []
-    }
-    
-    /// UserDefaults에서 지출 데이터를 로드하여 expenseData에 저장하는 메서드
-    func loadExpenseData() {
-
-    }
-    
-    /// 선택된 날짜의 총 지출 금액을 계산하는 메서드
-    /// - Parameter date: 총 지출 금액을 계산하는 날짜
-    /// - Returns: 해당 날짜의 총 지출 금액
-    func totalExpense(for date: Date) -> Double {
-        let expenses = expenseData[date] ?? []
-        return expenses.reduce(0) { $0 + $1.amount }
-    }
-    
     /// ViewModel의 Input을 Output으로 변환하는 메서드
     /// - Parameter input: ViewModel의 Input
     /// - Returns: ViewModel의 Output
@@ -96,7 +77,33 @@ class CalendarViewModel: ViewModelType {
             .emit(to: currentPageRelay)
             .disposed(by: disposeBag)
         
-        return Output(updatedDate: self.currentPageRelay)
+        return Output(
+            updatedDate: self.currentPageRelay,
+            expenses: expenseRelay
+        )
+    }
+    
+    /// Coredata에서 지출 데이터를 로드하여 expenseData에 저장하는 메서드
+    func loadExpenseData() {
+        let expenses = CoreDataManager.shared.fetch(
+            type: MyCashBookEntity.self,
+            predicate: cashBookID
+        )
+        
+        // amount외 원화 객체 수정예정
+        let models = expenses.map { entity -> MockMyCashBookModel in
+            return MockMyCashBookModel(
+                amount: entity.amount,
+                cashBookID: entity.cashBookID ?? UUID(),
+                category: entity.category ?? "",
+                country: entity.country ?? "",
+                expenseDate: entity.expenseDate ?? Date(),
+                note: entity.note ?? "",
+                payment: entity.payment
+            )
+        }
+        
+        expenseRelay.accept(models)
     }
     
     // MARK: - Helper Methods
@@ -112,5 +119,23 @@ class CalendarViewModel: ViewModelType {
     /// - Returns: 다음 달의 날짜
     private func nextMonth(from date: Date) -> Date {
         return Calendar.current.date(byAdding: .month, value: 1, to: date) ?? date
+    }
+    
+    
+    /// 지정된 날짜에 해당하는 지출내역을 가져오는 메서드
+    /// - Parameter date: 조회하는 날짜
+    /// - Returns: 해당 날짜의 지출 내역 배열
+    func expensesForDate(_ date: Date) -> [MockMyCashBookModel] {
+        return expenseRelay.value.filter { expense in
+            Calendar.current.isDate(expense.expenseDate, inSameDayAs: date)
+        }
+    }
+    
+    /// 선택된 날짜의 총 지출 금액을 계산하는 메서드 (amount -> 원화 객체로 수정예정)
+    /// - Parameter date: 총 지출 금액을 계산하는 날짜
+    /// - Returns: 해당 날짜의 총 지출 금액
+    func totalExpense(for date: Date) -> Double {
+        let dailyExpenses = expensesForDate(date)
+        return dailyExpenses.reduce(0) { $0 + $1.amount }
     }
 }

--- a/TripLog/TripLog/Feat-Jamong/ViewModel/CalendarViewModel.swift
+++ b/TripLog/TripLog/Feat-Jamong/ViewModel/CalendarViewModel.swift
@@ -12,6 +12,11 @@ import Then
 import SnapKit
 import FSCalendar
 
+// 1. CashBookId를 받아오는 로직 [완료]
+// 2. CoreData와 연결하여 CashBookId를 통해 데이터를 가져오고 삭제, 수정할 수 있는 로직
+// 3. ViewController에 Date에 따른 ExpenseLabel 보내주는 로직
+// 4. 캘린더뷰 - 지출목록의 Date에 따른 데이터 연결해주는 로직
+// 5. 지출목록의 추가하고 삭제할때 바인딩하는 로직
 
 class CalendarViewModel: ViewModelType {
     // MARK: - Input & Output
@@ -27,6 +32,9 @@ class CalendarViewModel: ViewModelType {
     // MARK: - Properties
     let disposeBag = DisposeBag()
     
+    // 가계부 ID 저장
+    private let cashBookID: UUID
+    
     // 지출 데이터를 저장
     private var expenseData: [Date: [MockMyCashBookModel]] = [:]
     
@@ -35,6 +43,13 @@ class CalendarViewModel: ViewModelType {
     
     // 현재 페이지를 저장하는 Relay
     private let currentPageRelay = BehaviorRelay<Date>(value: Date())
+    
+    
+    // MARK: - Initalization
+    init(cashBookID: UUID) {
+        self.cashBookID = cashBookID
+    }
+    
     
     // MARK: - Method
     // expensesData 접근가능 메서드


### PR DESCRIPTION
이슈 번호: #39 

## 요약
1. 캘린더 VC에 이니셜라이저를 설정하여 연결할때 CashBookID를 주입하게 함
2. CashBookID를 통한 CoreData와 연결 및 MockMyCashBook 데이터를 가져오고 저장하는 로직 구현
3. 캘린더 일자의 expensLabel의 데이터 전달을 위해 총 지출 금액을 계산하는 로직을 구현하고 ViewController에 연결해줌

## 작업 상세 내용
1번에 대한 작업
```swift
// CalendarViewModel.swift

    // 가계부 ID 저장
    private let cashBookID: UUID
    .
    .
    .
    // MARK: - Initalization
    init(cashBookID: UUID) {
        self.cashBookID = cashBookID
        loadExpenseData()
    }

// CalendarViewController.swift

    /// 가계부 ID 받아오기
    /// - Parameter cashBook: 가계부 ID
    init(cashBook: UUID) {
        self.calendarViewModel = CalendarViewModel(cashBookID: cashBook)
        super.init(nibName: nil, bundle: nil)
    }
    
    required init?(coder: NSCoder) {
        fatalError("init(coder:) has not been implemented")
    }
```

2번에 대한 작업
```swift
// CalendarViewModel.swift

    // 지출 데이터를 저장
    private let expenseRelay = BehaviorRelay<[MockMyCashBookModel]>(value: [])

    // MARK: - Initalization
    init(cashBookID: UUID) {
        self.cashBookID = cashBookID
        loadExpenseData()
    }

    /// Coredata에서 지출 데이터를 로드하여 expenseData에 저장하는 메서드
    func loadExpenseData() {
        let expenses = CoreDataManager.shared.fetch(
            type: MyCashBookEntity.self,
            predicate: cashBookID
        )
        
        // amount외 원화 객체 수정예정
        let models = expenses.map { entity -> MockMyCashBookModel in
            return MockMyCashBookModel(
                amount: entity.amount,
                cashBookID: entity.cashBookID ?? UUID(),
                category: entity.category ?? "",
                country: entity.country ?? "",
                expenseDate: entity.expenseDate ?? Date(),
                note: entity.note ?? "",
                payment: entity.payment
            )
        }
        
        expenseRelay.accept(models)
    }


    /// 지정된 날짜에 해당하는 지출내역을 가져오는 메서드
    /// - Parameter date: 조회하는 날짜
    /// - Returns: 해당 날짜의 지출 내역 배열
    func expensesForDate(_ date: Date) -> [MockMyCashBookModel] {
        return expenseRelay.value.filter { expense in
            Calendar.current.isDate(expense.expenseDate, inSameDayAs: date)
        }
    }
```

3번에 대한 작업
```swift
// CalendarViewModel.swift

    struct Output {
        let updatedDate: BehaviorRelay<Date>
        let expenses: BehaviorRelay<[MockMyCashBookModel]>
    }

    /// 선택된 날짜의 총 지출 금액을 계산하는 메서드 (amount -> 원화 객체로 수정예정)
    /// - Parameter date: 총 지출 금액을 계산하는 날짜
    /// - Returns: 해당 날짜의 총 지출 금액
    func totalExpense(for date: Date) -> Double {
        let dailyExpenses = expensesForDate(date)
        return dailyExpenses.reduce(0) { $0 + $1.amount }
    }

// CalendarViewController.swift

    /// 셀의 지출금액 레이블을 설정하는 메서드
    /// - Parameters:
    ///   - cell: 설정할 캘린더 커스텀 셀
    ///   - date: 지출금액을 계산할 날짜
    private func configureCellExpense(_ cell: CalendarCustomCell, for date: Date) {
        let totalExpense = calendarViewModel.totalExpense(for: date)
        if totalExpense > 0 {
            cell.expenseLabel.text = "\(Int(totalExpense))"
            cell.expenseLabel.isHidden = false
        } else {
            cell.expenseLabel.text = nil
            cell.expenseLabel.isHidden = true
        }
    }
```
## 리뷰어 공유사항
크루아상이 해준 리팩토링 부분과 겹치기 때문에 머지 후 
다음 작업 진행을 해야할 것 같습니다.

남은 작업
- 캘린더뷰 - 지출목록의 Date에 따른 데이터 연결해주는 로직
- 지출목록의 추가하고 삭제할때 바인딩하는 로직

## 스크린샷(선택)
- expensLabel에 amount값이 채워지는 것을 확인
![Simulator Screenshot - iPhone 16 - 2025-02-09 at 20 26 56](https://github.com/user-attachments/assets/87f7ed8f-a591-4c8a-b183-de80f4236229)