### PR TITLE
[feat] MyCashBookEntity 계산값 추가

### DIFF
--- a/TripLog/TripLog/Application/TripLog.xcdatamodeld/TripLog.xcdatamodel/contents
+++ b/TripLog/TripLog/Application/TripLog.xcdatamodeld/TripLog.xcdatamodel/contents
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="23605" systemVersion="24B91" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="23605" systemVersion="24C101" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
     <entity name="CashBookEntity" representedClassName="CashBookEntity" syncable="YES" codeGenerationType="class">
         <attribute name="budget" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES"/>
         <attribute name="departure" optional="YES" attributeType="String"/>
@@ -16,6 +16,7 @@
     </entity>
     <entity name="MyCashBookEntity" representedClassName="MyCashBookEntity" syncable="YES" codeGenerationType="class">
         <attribute name="amount" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES"/>
+        <attribute name="caculatedAmount" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="cashBookID" optional="YES" attributeType="UUID" usesScalarValueType="NO"/>
         <attribute name="category" optional="YES" attributeType="String"/>
         <attribute name="country" optional="YES" attributeType="String"/>

--- a/TripLog/TripLog/Feat-Crois/ModalViewController/View/ModalViewController.swift
+++ b/TripLog/TripLog/Feat-Crois/ModalViewController/View/ModalViewController.swift
@@ -128,6 +128,7 @@ private extension ModalViewController {
                 
                 let consumptionData = MyCashBookEntity.Model(amount: data.1.amount,
                                                              cashBookID: data.1.cashBookID,
+                                                             caculatedAmount: 1234, // TODO: (#102)수정필요
                                                              category: data.1.category,
                                                              country: data.1.country,
                                                              expenseDate: data.1.expenseDate,

--- a/TripLog/TripLog/Feat-Hamsik/Extension/MyCashBookEntity+Ext.swift
+++ b/TripLog/TripLog/Feat-Hamsik/Extension/MyCashBookEntity+Ext.swift
@@ -12,6 +12,7 @@ import CoreData
 struct MockMyCashBookModel {
     let amount: Double // 지출금액
     let cashBookID: UUID // 가계부 Entity ID
+    let caculatedAmount: Int // 계산값(원화)
     let category: String // 카테고리
     let country: String // 환율코드
     let expenseDate: Date // 지출일자
@@ -40,6 +41,7 @@ extension MyCashBookEntity: CoreDataManagable {
     
         let properties: [String: Any] = [
             element.amount : data.amount,
+            element.caculatedAmount : data.caculatedAmount,
             element.category : data.category,
             element.cashBookID : data.cashBookID,
             element.country : data.country,
@@ -114,6 +116,7 @@ extension MyCashBookEntity: CoreDataManagable {
         fetchRequest.predicate = NSPredicate(format: "\(element.id) == %@", entityID as CVarArg)
         let properties: [String: Any] = [
             element.amount : data.amount,
+            element.caculatedAmount : data.caculatedAmount,
             element.category : data.category,
             element.cashBookID : data.cashBookID,
             element.country : data.country,

--- a/TripLog/TripLog/Feat-Hamsik/Utility/Entities.swift
+++ b/TripLog/TripLog/Feat-Hamsik/Utility/Entities.swift
@@ -22,6 +22,7 @@ struct CurrencyElement {
 
 struct MyCashBookElement {
     let amount = "amount"
+    let caculatedAmount = "caculatedAmount"
     let category = "category"
     let cashBookID = "cashBookID"
     let country = "country"

--- a/TripLog/TripLog/Feat-Jamong/ViewModel/CalendarViewModel.swift
+++ b/TripLog/TripLog/Feat-Jamong/ViewModel/CalendarViewModel.swift
@@ -103,6 +103,7 @@ class CalendarViewModel: ViewModelType {
             return MockMyCashBookModel(
                 amount: entity.amount,
                 cashBookID: entity.cashBookID ?? self.cashBookID,
+                caculatedAmount: 1234, // TODO: (#102)수정필요
                 category: entity.category ?? "",
                 country: entity.country ?? "",
                 expenseDate: entity.expenseDate ?? Date(),

--- a/TripLog/TripLog/Feat-Stone/ViewModel/TodayViewModel.swift
+++ b/TripLog/TripLog/Feat-Stone/ViewModel/TodayViewModel.swift
@@ -62,6 +62,7 @@ class TodayViewModel {
                     MockMyCashBookModel(
                         amount: entity.amount,
                         cashBookID: entity.cashBookID ?? UUID(),
+                        caculatedAmount: 1234, // TODO: (#102)수정필요
                         category: entity.category ?? "기타",
                         country: entity.country ?? "USD",
                         expenseDate: entity.expenseDate ?? Date(),


### PR DESCRIPTION
- `Attributes` 추가
- `MyCashBookElement` 추가
- `Create`, `Update` 메서드 수정

이슈 번호: 이슈 없음

## 요약
- 지출내역(`MyCashBook`) 저장 시, 계산된 값도 저장하는 코드 추가

## 작업 상세 내용
### Attributes 추가
```swift
<attribute name="caculatedAmount" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
```
### 편의성 코드 추가
```swift
struct MyCashBookElement {
    let caculatedAmount = "caculatedAmount"
}
```
### `Create`, `Update` 함수 수정
```swift
struct MockMyCashBookModel {
    let amount: Double // 지출금액
    let cashBookID: UUID // 가계부 Entity ID
    let caculatedAmount: Int // 계산값(원화) ---> 추가
    let category: String // 카테고리
    // 중략
}

let properties: [String: Any] = [
            element.amount : data.amount,
            element.caculatedAmount : data.caculatedAmount, ---> 추가
            element.category : data.category,
            element.cashBookID : data.cashBookID,
            element.country : data.country,
            // 중략
]
```

## 리뷰어 공유사항
- 단순 속성 추가 작업입니다.
- `// TODO: (#102)수정필요` 라는 주석을 통해서
빌드에러를 임시해결하는 코드가 있어요
`cmd+F` 로 검색해서 수정해주세요!
@Crois0509 @Jamong-mini @dnwn1211 

