### PR TITLE
[Feat] 모달뷰 지출 내역 키보드 타입 수정

### DIFF
--- a/TripLog/TripLog/Feat-Crois/ModalViewController/Model/ModalConsumptionData.swift
+++ b/TripLog/TripLog/Feat-Crois/ModalViewController/Model/ModalConsumptionData.swift
@@ -11,5 +11,5 @@ import Foundation
 struct ModalConsumptionData {
     let cashBookID: UUID
     let date: Date
-    let exchangeRate: CurrencyRate
+    let exchangeRate: [CurrencyEntity]
 }

--- a/TripLog/TripLog/Feat-Crois/ModalViewController/Model/ModalViewState.swift
+++ b/TripLog/TripLog/Feat-Crois/ModalViewController/Model/ModalViewState.swift
@@ -12,7 +12,7 @@ enum ModalViewState {
     case createNewCashBook
     case editCashBook(data: MockCashBookModel) // 가계부 수정시 데이터 입력
     case createNewConsumption(data: ModalConsumptionData)
-    case editConsumption(data: MockMyCashBookModel, exchangeRate: CurrencyRate) // 지출 내역 수정 시 데이터 입력
+    case editConsumption(data: MockMyCashBookModel, exchangeRate: [CurrencyEntity]) // 지출 내역 수정 시 데이터 입력
     
     /// 각 상태에 따라 모달 뷰의 타이틀을 결정하는 프로퍼티
     var modalTitle: String {

--- a/TripLog/TripLog/Feat-Crois/ModalViewController/View/ModalAmountView.swift
+++ b/TripLog/TripLog/Feat-Crois/ModalViewController/View/ModalAmountView.swift
@@ -179,7 +179,7 @@ private extension ModalAmountView {
 
 extension Reactive where Base: ModalAmountView {
     /// 금액뷰의 텍스트필드가 비었는지 확인하는 옵저버블
-    var amountViewIsBlank: Observable<Bool> {
+    var amountViewIsEmpty: Observable<Bool> {
         return base.textField.rx.text.orEmpty
             .map { Double($0) == nil }
             .distinctUntilChanged()

--- a/TripLog/TripLog/Feat-Crois/ModalViewController/View/ModalDatePicker.swift
+++ b/TripLog/TripLog/Feat-Crois/ModalViewController/View/ModalDatePicker.swift
@@ -154,7 +154,7 @@ extension Reactive where Base: ModalDatePicker {
     }
     
     /// DatePicker의 날짜가 선택되었는지 확인하는 옵저버블
-    var datePickerIsBlank: Observable<Bool> {
+    var datePickerIsEmpty: Observable<Bool> {
         return base.textField.rx.text.orEmpty
             .map { $0.count <= 0 }
             .distinctUntilChanged()

--- a/TripLog/TripLog/Feat-Crois/ModalViewController/View/ModalDateView.swift
+++ b/TripLog/TripLog/Feat-Crois/ModalViewController/View/ModalDateView.swift
@@ -16,13 +16,13 @@ final class ModalDateView: UIView {
     
     // MARK: - Rx Properties
     
-    private let startDateIsBlank = BehaviorSubject<Bool>(value: true)
-    private let endDateIsBlank = BehaviorSubject<Bool>(value: true)
+    private let startDateIsEmpty = BehaviorSubject<Bool>(value: true)
+    private let endDateIsEmpty = BehaviorSubject<Bool>(value: true)
     
     /// 날짜가 모두 선택되었는지 검사하고 이벤트를 방출하는 옵저버블
-    fileprivate lazy var dateIsBlank: Observable<Bool> = {
+    fileprivate lazy var dateIsEmpty: Observable<Bool> = {
         return Observable
-            .combineLatest(startDateIsBlank, endDateIsBlank)
+            .combineLatest(startDateIsEmpty, endDateIsEmpty)
             .map { $0 || $1 }
             .distinctUntilChanged()
             .share(replay: 1, scope: .whileConnected)
@@ -159,8 +159,8 @@ private extension ModalDateView {
                 
             }.disposed(by: disposeBag)
         
-        startDatePicker.rx.datePickerIsBlank
-            .bind(to: startDateIsBlank)
+        startDatePicker.rx.datePickerIsEmpty
+            .bind(to: startDateIsEmpty)
             .disposed(by: disposeBag)
     }
     
@@ -185,8 +185,8 @@ private extension ModalDateView {
                 
             }.disposed(by: disposeBag)
         
-        endDatePicker.rx.datePickerIsBlank
-            .bind(to: endDateIsBlank)
+        endDatePicker.rx.datePickerIsEmpty
+            .bind(to: endDateIsEmpty)
             .disposed(by: disposeBag)
     }
     
@@ -196,7 +196,7 @@ private extension ModalDateView {
 
 extension Reactive where Base: ModalDateView {
     /// 날짜가 선택되었는지 검사하고 이벤트를 방출하는 옵저버블
-    var dateIsBlank: Observable<Bool> {
-        return base.dateIsBlank
+    var dateIsEmpty: Observable<Bool> {
+        return base.dateIsEmpty
     }
 }

--- a/TripLog/TripLog/Feat-Crois/ModalViewController/View/ModalTextField.swift
+++ b/TripLog/TripLog/Feat-Crois/ModalViewController/View/ModalTextField.swift
@@ -127,7 +127,7 @@ private extension ModalTextField {
 
 extension Reactive where Base: ModalTextField {
     /// 텍스트필드의 입력란이 비었는지 검사하고 이벤트를 방출하는 옵저버블
-    var textFieldIsBlank: Observable<Bool> {
+    var textFieldIsEmpty: Observable<Bool> {
         return base.textField.rx.text.orEmpty
             .map { $0.count <= 0 }
             .distinctUntilChanged()

--- a/TripLog/TripLog/Feat-Crois/ModalViewController/View/ModalView.swift
+++ b/TripLog/TripLog/Feat-Crois/ModalViewController/View/ModalView.swift
@@ -64,7 +64,7 @@ final class ModalView: UIView {
     private var cashBookID: UUID?
     private var consumptionID: UUID?
     private var expenseDate: Date?
-    private var exchangeRate: CurrencyRate?
+    private var exchangeRate: [CurrencyEntity]?
     
     // MARK: - Initializer
     
@@ -199,12 +199,9 @@ private extension ModalView {
     ///   - amount: 기준 원화
     /// - Returns: 환율을 적용한 원화
     func exchangeRateCalculation(_ country: String, _ amount: Double) -> Double {
-        guard
-            let currency = exchangeRate?.filter({ $0.curUnit == country }).first,
-            let rate = Double(currency.dealBasR ?? "")
-        else { return 0 }
+        guard let currency = exchangeRate?.filter({ $0.currencyCode == country }).first else { return 0 }
         
-        let result = amount / rate
+        let result = amount / currency.baseRate
         return result
     }
     

--- a/TripLog/TripLog/Feat-Crois/ModalViewController/View/ModalView.swift
+++ b/TripLog/TripLog/Feat-Crois/ModalViewController/View/ModalView.swift
@@ -22,17 +22,17 @@ final class ModalView: UIView {
     fileprivate let cashBookActiveButtonTapped = PublishRelay<ModalCashBookData>()
     fileprivate let consumptionActiveButtonTapped = PublishRelay<ModalConsumptionData>()
     
-    private let firstTextFieldIsBlank = BehaviorSubject<Bool>(value: true)
-    private let secondTextFieldIsBlank = BehaviorSubject<Bool>(value: true)
-    private let thirdTextFieldIsBlank = BehaviorSubject<Bool>(value: true)
-    private let dateIsBlank = BehaviorSubject<Bool>(value: false)
+    private let firstTextFieldIsEmpty = BehaviorSubject<Bool>(value: true)
+    private let secondTextFieldIsEmpty = BehaviorSubject<Bool>(value: true)
+    private let thirdTextFieldIsEmpty = BehaviorSubject<Bool>(value: true)
+    private let dateIsEmpty = BehaviorSubject<Bool>(value: false)
     
-    fileprivate lazy var allSectionIsBlank: Observable<Bool> = {
+    fileprivate lazy var allSectionIsEmpty: Observable<Bool> = {
         return Observable
-            .combineLatest(firstTextFieldIsBlank,
-                           secondTextFieldIsBlank,
-                           thirdTextFieldIsBlank,
-                           dateIsBlank
+            .combineLatest(firstTextFieldIsEmpty,
+                           secondTextFieldIsEmpty,
+                           thirdTextFieldIsEmpty,
+                           dateIsEmpty
             )
             .map { $0 || $1 || $2 || $3 }
             .distinctUntilChanged()
@@ -214,20 +214,20 @@ private extension ModalView {
                let thirdSection = self.thirdSection as? ModalTextField,
                let forthSection = self.forthSection as? ModalDateView
             {
-                firstSection.rx.textFieldIsBlank
-                    .bind(to: firstTextFieldIsBlank)
+                firstSection.rx.textFieldIsEmpty
+                    .bind(to: firstTextFieldIsEmpty)
                     .disposed(by: disposeBag)
                 
-                secondSection.rx.textFieldIsBlank
-                    .bind(to: secondTextFieldIsBlank)
+                secondSection.rx.textFieldIsEmpty
+                    .bind(to: secondTextFieldIsEmpty)
                     .disposed(by: disposeBag)
                 
-                thirdSection.rx.textFieldIsBlank
-                    .bind(to: thirdTextFieldIsBlank)
+                thirdSection.rx.textFieldIsEmpty
+                    .bind(to: thirdTextFieldIsEmpty)
                     .disposed(by: disposeBag)
                 
-                forthSection.rx.dateIsBlank
-                    .bind(to: dateIsBlank)
+                forthSection.rx.dateIsEmpty
+                    .bind(to: dateIsEmpty)
                     .disposed(by: disposeBag)
             }
             
@@ -244,20 +244,20 @@ private extension ModalView {
                 
                 self.cashBookID = data.id
                 
-                firstSection.rx.textFieldIsBlank
-                    .bind(to: firstTextFieldIsBlank)
+                firstSection.rx.textFieldIsEmpty
+                    .bind(to: firstTextFieldIsEmpty)
                     .disposed(by: disposeBag)
                 
-                secondSection.rx.textFieldIsBlank
-                    .bind(to: secondTextFieldIsBlank)
+                secondSection.rx.textFieldIsEmpty
+                    .bind(to: secondTextFieldIsEmpty)
                     .disposed(by: disposeBag)
                 
-                thirdSection.rx.textFieldIsBlank
-                    .bind(to: thirdTextFieldIsBlank)
+                thirdSection.rx.textFieldIsEmpty
+                    .bind(to: thirdTextFieldIsEmpty)
                     .disposed(by: disposeBag)
                 
-                forthSection.rx.dateIsBlank
-                    .bind(to: dateIsBlank)
+                forthSection.rx.dateIsEmpty
+                    .bind(to: dateIsEmpty)
                     .disposed(by: disposeBag)
             }
             
@@ -271,16 +271,16 @@ private extension ModalView {
                 self.expenseDate = data.date
                 self.exchangeRate = data.exchangeRate
                 
-                secondSection.rx.textFieldIsBlank
-                    .bind(to: firstTextFieldIsBlank)
+                secondSection.rx.textFieldIsEmpty
+                    .bind(to: firstTextFieldIsEmpty)
                     .disposed(by: disposeBag)
                 
-                thirdSection.rx.textFieldIsBlank
-                    .bind(to: secondTextFieldIsBlank)
+                thirdSection.rx.textFieldIsEmpty
+                    .bind(to: secondTextFieldIsEmpty)
                     .disposed(by: disposeBag)
                 
-                forthSection.rx.amountViewIsBlank
-                    .bind(to: thirdTextFieldIsBlank)
+                forthSection.rx.amountViewIsEmpty
+                    .bind(to: thirdTextFieldIsEmpty)
                     .disposed(by: disposeBag)
             }
             
@@ -300,16 +300,16 @@ private extension ModalView {
                 self.expenseDate = data.expenseDate
                 self.exchangeRate = rate
                 
-                secondSection.rx.textFieldIsBlank
-                    .bind(to: firstTextFieldIsBlank)
+                secondSection.rx.textFieldIsEmpty
+                    .bind(to: firstTextFieldIsEmpty)
                     .disposed(by: disposeBag)
                 
-                thirdSection.rx.textFieldIsBlank
-                    .bind(to: secondTextFieldIsBlank)
+                thirdSection.rx.textFieldIsEmpty
+                    .bind(to: secondTextFieldIsEmpty)
                     .disposed(by: disposeBag)
                 
-                forthSection.rx.amountViewIsBlank
-                    .bind(to: thirdTextFieldIsBlank)
+                forthSection.rx.amountViewIsEmpty
+                    .bind(to: thirdTextFieldIsEmpty)
                     .disposed(by: disposeBag)
             }
         }
@@ -431,6 +431,6 @@ extension Reactive where Base: ModalView {
     
     /// 빈 값인 섹션이 있는지 검사하고 이벤트를 방출하는 옵저버블
     var checkBlankOfSections: Observable<Bool> {
-        return base.allSectionIsBlank
+        return base.allSectionIsEmpty
     }
 }

--- a/TripLog/TripLog/Feat-Crois/ModalViewController/View/ModalViewController.swift
+++ b/TripLog/TripLog/Feat-Crois/ModalViewController/View/ModalViewController.swift
@@ -97,7 +97,7 @@ private extension ModalViewController {
                 
                 guard !data.0 else {
                     guard let vc = AppHelpers.getTopViewController() else { return }
-                    let alert = AlertManager(title: "알림", message: "모든 입력을 채워주세요!!", cancelTitle: "확인")
+                    let alert = AlertManager(title: "알림", message: "모든 내용을 정확히 입력해주세요", cancelTitle: "확인")
                     alert.showAlert(on: vc, .alert)
                     return
                 }
@@ -121,7 +121,7 @@ private extension ModalViewController {
                 
                 guard !data.0 else {
                     guard let vc = AppHelpers.getTopViewController() else { return }
-                    let alert = AlertManager(title: "알림", message: "모든 입력을 채워주세요!!", cancelTitle: "확인")
+                    let alert = AlertManager(title: "알림", message: "모든 내용을 정확히 입력해주세요", cancelTitle: "확인")
                     alert.showAlert(on: vc, .alert)
                     return
                 }

--- a/TripLog/TripLog/Feat-Crois/ModalViewController/View/ModalViewController.swift
+++ b/TripLog/TripLog/Feat-Crois/ModalViewController/View/ModalViewController.swift
@@ -85,7 +85,7 @@ private extension ModalViewController {
             cancelButtonTapped: self.modalView.rx.cancelButtonTapped,
             cashBookActiveButtonTapped: self.modalView.rx.cashBookActiveButtonTapped,
             consumptionActiveButtonTapped: self.modalView.rx.consumptionActiveButtonTapped,
-            sectionIsBlank: self.modalView.rx.checkBlankOfSections
+            sectionIsEmpty: self.modalView.rx.checkBlankOfSections
         )
         
         let output = viewModel.transform(input: input)

--- a/TripLog/TripLog/Feat-Crois/ModalViewController/ViewModel/ModalViewModel.swift
+++ b/TripLog/TripLog/Feat-Crois/ModalViewController/ViewModel/ModalViewModel.swift
@@ -16,7 +16,7 @@ final class ModalViewModel: ViewModelType {
         let cancelButtonTapped: PublishRelay<Void>
         let cashBookActiveButtonTapped: PublishRelay<ModalView.ModalCashBookData>
         let consumptionActiveButtonTapped: PublishRelay<ModalView.ModalConsumptionData>
-        let sectionIsBlank: Observable<Bool>
+        let sectionIsEmpty: Observable<Bool>
     }
     
     struct Output {
@@ -31,14 +31,14 @@ final class ModalViewModel: ViewModelType {
     private let cashBookActive = PublishRelay<(Bool, ModalView.ModalCashBookData)>()
     private let consumptionActive = PublishRelay<(Bool, ModalView.ModalConsumptionData)>()
     
-    private var textFieldIsBlank: Bool?
+    private var textFieldIsEmpty: Bool?
     
     /// input을 output으로 변환해주는 메소드
     /// - Parameter input:
     /// **cancelButtonTapped**: 취소 버튼의 탭 이벤트를 방출하는 옵저버블
     /// **cashBookActiveButtonTapped**: 모달뷰가 가계부 상태일 때 active 버튼의 탭 이벤트를 방출하는 옵저버블
     /// **consumptionActiveButtonTapped**: 모달뷰가 지출 내역 상태일 때 active 버튼의 탭 이벤트를 방출하는 옵저버블
-    /// **sectionIsBlank**: 모달뷰의 섹션 중 빈 값이 있는지 검사하고 이벤트를 방출하는 옵저버블
+    /// **sectionIsEmpty**: 모달뷰의 섹션 중 빈 값이 있는지 검사하고 이벤트를 방출하는 옵저버블
     ///
     /// - Returns:
     /// **modalDismiss**: 취소 버튼이 눌리면 모달을 닫도록 이벤트를 방출하는 옵저버블
@@ -50,8 +50,8 @@ final class ModalViewModel: ViewModelType {
             .withUnretained(self)
             .emit { owner, data in
                 
-                guard let isBlank = owner.textFieldIsBlank else { return }
-                owner.cashBookActive.accept((isBlank, data))
+                guard let isEmpty = owner.textFieldIsEmpty else { return }
+                owner.cashBookActive.accept((isEmpty, data))
                 
             }.disposed(by: disposeBag)
         
@@ -60,8 +60,8 @@ final class ModalViewModel: ViewModelType {
             .withUnretained(self)
             .emit { owner, data in
                 
-                guard let isBlank = owner.textFieldIsBlank else { return }
-                owner.consumptionActive.accept((isBlank, data))
+                guard let isEmpty = owner.textFieldIsEmpty else { return }
+                owner.consumptionActive.accept((isEmpty, data))
                 
             }.disposed(by: disposeBag)
         
@@ -74,12 +74,12 @@ final class ModalViewModel: ViewModelType {
                 
             }.disposed(by: disposeBag)
         
-        input.sectionIsBlank
+        input.sectionIsEmpty
             .asSignal(onErrorSignalWith: .empty())
             .withUnretained(self)
-            .emit { owner, isBlank in
+            .emit { owner, isEmpty in
                 
-                owner.textFieldIsBlank = isBlank
+                owner.textFieldIsEmpty = isEmpty
                 
             }.disposed(by: disposeBag)
         

--- a/TripLog/TripLog/Source/Extension/Double+Extension.swift
+++ b/TripLog/TripLog/Source/Extension/Double+Extension.swift
@@ -1,0 +1,18 @@
+//
+//  Double+Extension.swift
+//  TripLog
+//
+//  Created by 장상경 on 2/11/25.
+//
+
+import Foundation
+
+extension Double {
+    var formattedWithFormatter: String {
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .decimal
+        formatter.minimumFractionDigits = 0
+        formatter.maximumFractionDigits = 2
+        return formatter.string(from: NSNumber(value: self)) ?? "\(self)"
+    }
+}


### PR DESCRIPTION
이슈 번호: close #104 

## 요약
- 모달뷰에서 지출 내역을 수정/추가 할 때 금액을 입력하는 텍스트필드를 리팩토링

## 작업 상세 내용
기존에는 지출 내역을 추가하거나 수정할 때, 모달에서 금액을 입력하려고 하면 숫자 키보드만 표시되어서
소수점을 입력하지 못하는 문제가 있었습니다.

이를 `UITextField`의 키보드 타입을 변경하여 수정하였고,
유저가 만약 `.`만 입력한다거나 잘못된 값을 입력할 수도 있기 때문에 이를 방지할 수 있도록 로직을 수정했습니다.

또, `.`을 여러번 입력할 수 없도록 방지하는 로직을 구현했습니다.
