### PR TITLE
[Refactor] 캘린더 amount값을 caculatedAmount로 리팩토링 

### DIFF
--- a/TripLog/TripLog/Application/TripLog.xcdatamodeld/TripLog.xcdatamodel/contents
+++ b/TripLog/TripLog/Application/TripLog.xcdatamodeld/TripLog.xcdatamodel/contents
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="23605" systemVersion="24C101" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="23605" systemVersion="24B83" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
     <entity name="CashBookEntity" representedClassName="CashBookEntity" syncable="YES" codeGenerationType="class">
         <attribute name="budget" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES"/>
         <attribute name="departure" optional="YES" attributeType="String"/>
@@ -16,7 +16,7 @@
     </entity>
     <entity name="MyCashBookEntity" representedClassName="MyCashBookEntity" syncable="YES" codeGenerationType="class">
         <attribute name="amount" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES"/>
-        <attribute name="caculatedAmount" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="caculatedAmount" optional="YES" attributeType="Double" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="cashBookID" optional="YES" attributeType="UUID" usesScalarValueType="NO"/>
         <attribute name="category" optional="YES" attributeType="String"/>
         <attribute name="country" optional="YES" attributeType="String"/>

--- a/TripLog/TripLog/Feat-Hamsik/Extension/MyCashBookEntity+Ext.swift
+++ b/TripLog/TripLog/Feat-Hamsik/Extension/MyCashBookEntity+Ext.swift
@@ -12,7 +12,7 @@ import CoreData
 struct MockMyCashBookModel {
     let amount: Double // 지출금액
     let cashBookID: UUID // 가계부 Entity ID
-    let caculatedAmount: Int // 계산값(원화)
+    let caculatedAmount: Double // 계산값(원화)
     let category: String // 카테고리
     let country: String // 환율코드
     let expenseDate: Date // 지출일자

--- a/TripLog/TripLog/Feat-Jamong/View/CalendarExpenseView/CalendarExpenseCell.swift
+++ b/TripLog/TripLog/Feat-Jamong/View/CalendarExpenseView/CalendarExpenseCell.swift
@@ -110,8 +110,8 @@ final class CalendarExpenseCell: UITableViewCell {
         
         categoryLabel.text = "\(model.category) / \(model.payment ? "카드" : "현금")"
         
-        // calculatedAmount 들어오면 넣을 예정
-        let formattedWonAmount = numberFormatter.string(from: NSNumber(value: Int(model.caculatedAmount))) ?? "0"
+        let roundedAmount = Int(round(model.caculatedAmount))
+        let formattedWonAmount = numberFormatter.string(from: NSNumber(value: roundedAmount)) ?? "0"
         wonAmountLabel.text = "\(formattedWonAmount)원"
     }
     

--- a/TripLog/TripLog/Feat-Jamong/View/CalendarExpenseView/CalendarExpenseCell.swift
+++ b/TripLog/TripLog/Feat-Jamong/View/CalendarExpenseView/CalendarExpenseCell.swift
@@ -111,8 +111,7 @@ final class CalendarExpenseCell: UITableViewCell {
         categoryLabel.text = "\(model.category) / \(model.payment ? "카드" : "현금")"
         
         // calculatedAmount 들어오면 넣을 예정
-        let wonAmount = model.amount * 1000.0 
-        let formattedWonAmount = numberFormatter.string(from: NSNumber(value: wonAmount)) ?? "0"
+        let formattedWonAmount = numberFormatter.string(from: NSNumber(value: Int(model.caculatedAmount))) ?? "0"
         wonAmountLabel.text = "\(formattedWonAmount)원"
     }
     

--- a/TripLog/TripLog/Feat-Jamong/View/CalendarExpenseView/CalendarExpenseListHeaderView.swift
+++ b/TripLog/TripLog/Feat-Jamong/View/CalendarExpenseView/CalendarExpenseListHeaderView.swift
@@ -160,8 +160,8 @@ final class CalendarExpenseListHeaderView: UIView {
         numberFormatter.maximumFractionDigits = 2
         numberFormatter.usesGroupingSeparator = true
         
-        let formattedExpense = numberFormatter.string(from: NSNumber(value: expense)) ?? "0"
-        let formattedBalance = numberFormatter.string(from: NSNumber(value: balance)) ?? "0"
+        let formattedExpense = numberFormatter.string(from: NSNumber(value: Int(expense))) ?? "0"
+        let formattedBalance = numberFormatter.string(from: NSNumber(value: Int(balance))) ?? "0"
         
         dateLabel.text = formatter.string(from: date)
         expenseAmountLabel.text = "\(formattedExpense)원"

--- a/TripLog/TripLog/Feat-Jamong/View/CalendarExpenseView/CalendarExpenseListHeaderView.swift
+++ b/TripLog/TripLog/Feat-Jamong/View/CalendarExpenseView/CalendarExpenseListHeaderView.swift
@@ -150,7 +150,7 @@ final class CalendarExpenseListHeaderView: UIView {
         }
     }
     
-    func configure(date: Date, expense: Double, balance: Double) {
+    func configure(date: Date, expense: Int, balance: Int) {
         let formatter = DateFormatter()
         formatter.dateFormat = "M월 d일 지출"
         

--- a/TripLog/TripLog/Feat-Jamong/View/CalendarExpenseView/CalendarExpenseView.swift
+++ b/TripLog/TripLog/Feat-Jamong/View/CalendarExpenseView/CalendarExpenseView.swift
@@ -96,9 +96,9 @@ final class CalendarExpenseView: UIView {
     ///   - date: 선택된 날짜
     ///   - expenses: 해당 날짜의 지출 항목 배열
     ///   - balance: 현재 잔액
-    func configure(date: Date, expenses: [MockMyCashBookModel], balance: Double) {
+    func configure(date: Date, expenses: [MockMyCashBookModel], balance: Int) {
         self.expenses = expenses
-        let totalExpense = Double(expenses.reduce(0) { $0 + $1.caculatedAmount })
+        let totalExpense = expenses.reduce(0) { $0 + Int(round($1.caculatedAmount))}
         headerView.configure(date: date, expense: totalExpense, balance: balance)
         
         emptyStateLabel.isHidden = !expenses.isEmpty

--- a/TripLog/TripLog/Feat-Jamong/View/CalendarExpenseView/CalendarExpenseView.swift
+++ b/TripLog/TripLog/Feat-Jamong/View/CalendarExpenseView/CalendarExpenseView.swift
@@ -70,8 +70,6 @@ final class CalendarExpenseView: UIView {
         tableView.snp.makeConstraints {
             $0.top.equalTo(headerView.snp.bottom)
             $0.leading.trailing.equalToSuperview()
-            //            $0.height.equalTo(60).priority(.low)
-            //            $0.height.equalTo(tableView.contentSize.height).priority(.high)
             $0.height.equalTo(0)
             $0.bottom.equalToSuperview()
         }
@@ -100,7 +98,7 @@ final class CalendarExpenseView: UIView {
     ///   - balance: 현재 잔액
     func configure(date: Date, expenses: [MockMyCashBookModel], balance: Double) {
         self.expenses = expenses
-        let totalExpense = Double(expenses.reduce(0) { $0 + $1.amount })
+        let totalExpense = Double(expenses.reduce(0) { $0 + $1.caculatedAmount })
         headerView.configure(date: date, expense: totalExpense, balance: balance)
         
         emptyStateLabel.isHidden = !expenses.isEmpty

--- a/TripLog/TripLog/Feat-Jamong/View/CalendarViewController.swift
+++ b/TripLog/TripLog/Feat-Jamong/View/CalendarViewController.swift
@@ -183,7 +183,7 @@ final class CalendarViewController: UIViewController {
                 
                 let rates = CoreDataManager.shared.fetch(
                     type: CurrencyEntity.self,
-                    predicate: nil
+                    predicate: Date.formattedDateString(from: date)
                 )
                 
                 return ModalViewManager.showModal(state: .createNewConsumption(data: .init(cashBookID: owner.calendarViewModel.cashBookID, date: date, exchangeRate: rates)))
@@ -338,15 +338,12 @@ extension CalendarViewController: UITableViewDelegate {
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         let expenses = calendarViewModel.expensesForDate(date: calendarViewModel.selectedDate)
         let expense = expenses[indexPath.row]
-        let originalID = expense.id
-        let rates = CoreDataManager.shared.fetch(type: CurrencyEntity.self, predicate: nil)
+        let rates = CoreDataManager.shared.fetch(type: CurrencyEntity.self, predicate: Date.formattedDateString(from: expense.expenseDate))
         
         ModalViewManager.showModal(state: .editConsumption(data: expense, exchangeRate: rates))
             .compactMap { $0 as? MockMyCashBookModel }
             .subscribe(onNext: { [weak self] updatedExpense in
-                var modifiedExpense = updatedExpense
-                modifiedExpense.id = originalID  // ID 업데이트
-                self?.calendarViewModel.updateExpense(modifiedExpense)
+                self?.calendarViewModel.updateExpense(updatedExpense)
             })
             .disposed(by: disposeBag)
         

--- a/TripLog/TripLog/Feat-Jamong/View/CalendarViewController.swift
+++ b/TripLog/TripLog/Feat-Jamong/View/CalendarViewController.swift
@@ -177,11 +177,16 @@ final class CalendarViewController: UIViewController {
             }
             .disposed(by: disposeBag)
         
-        // addButton에 date는 셀에 받아온 데이트를 넣어야할듯
         output.addButtonTapped
             .withUnretained(self)
             .flatMap { owner, date in
-                ModalViewManager.showModal(state: .createNewConsumption(data: .init(cashBookID: owner.calendarViewModel.cashBookID, date: date, exchangeRate: [])))
+                
+                let rates = CoreDataManager.shared.fetch(
+                    type: CurrencyEntity.self,
+                    predicate: nil
+                )
+                
+                return ModalViewManager.showModal(state: .createNewConsumption(data: .init(cashBookID: owner.calendarViewModel.cashBookID, date: date, exchangeRate: rates)))
                     .compactMap {
                         $0 as? MockMyCashBookModel
                     }
@@ -333,24 +338,15 @@ extension CalendarViewController: UITableViewDelegate {
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         let expenses = calendarViewModel.expensesForDate(date: calendarViewModel.selectedDate)
         let expense = expenses[indexPath.row]
-        let originalID = expense.id  // 원본 ID 저장 (안하면.. 저장이안됌)
+        let originalID = expense.id
+        let rates = CoreDataManager.shared.fetch(type: CurrencyEntity.self, predicate: nil)
         
-        ModalViewManager.showModal(state: .editConsumption(data: expense, exchangeRate: [])) // 환율 정보 추출 PR 머지되면 연결
+        ModalViewManager.showModal(state: .editConsumption(data: expense, exchangeRate: rates))
             .compactMap { $0 as? MockMyCashBookModel }
-            .map { updatedExpense in
-                MockMyCashBookModel(
-                    amount: updatedExpense.amount,
-                    cashBookID: updatedExpense.cashBookID,
-                    category: updatedExpense.category,
-                    country: updatedExpense.country,
-                    expenseDate: updatedExpense.expenseDate,
-                    id: originalID,
-                    note: updatedExpense.note,
-                    payment: updatedExpense.payment
-                )
-            }
             .subscribe(onNext: { [weak self] updatedExpense in
-                self?.calendarViewModel.updateExpense(updatedExpense)
+                var modifiedExpense = updatedExpense
+                modifiedExpense.id = originalID  // ID 업데이트
+                self?.calendarViewModel.updateExpense(modifiedExpense)
             })
             .disposed(by: disposeBag)
         

--- a/TripLog/TripLog/Feat-Jamong/ViewModel/CalendarViewModel.swift
+++ b/TripLog/TripLog/Feat-Jamong/ViewModel/CalendarViewModel.swift
@@ -225,7 +225,7 @@ class CalendarViewModel: ViewModelType {
     /// - Returns: 해당 날짜의 총 지출 금액
     func totalExpense(date: Date) -> Double {
         let dailyExpenses = expensesForDate(date: date)
-        return dailyExpenses.reduce(0) { $0 + $1.amount }
+        return dailyExpenses.reduce(0) { $0 + $1.caculatedAmount }
     }
     
     /// 특정 날짜까지의 예산 잔액을 계산하는 메서드
@@ -237,7 +237,7 @@ class CalendarViewModel: ViewModelType {
             expense.expenseDate <= date
         }
         // 총 지출 계산
-        let totalExpense = Double(allExpenses.reduce(0.0) { $0 + $1.amount })
+        let totalExpense = Double(allExpenses.reduce(0.0) { $0 + $1.caculatedAmount })
         // 초기 예산에서 총 지출을 빼서 잔액 계산
         return Double(balance) - totalExpense
     }

--- a/TripLog/TripLog/Feat-Jamong/ViewModel/CalendarViewModel.swift
+++ b/TripLog/TripLog/Feat-Jamong/ViewModel/CalendarViewModel.swift
@@ -29,7 +29,7 @@ class CalendarViewModel: ViewModelType {
     
     struct Output {
         let updatedDate: BehaviorRelay<Date>
-        let expenses: BehaviorRelay<(date: Date, data: [MockMyCashBookModel], balance: Double)>
+        let expenses: BehaviorRelay<(date: Date, data: [MockMyCashBookModel], balance: Int)>
         let addButtonTapped: PublishRelay<Date>
     }
     
@@ -52,7 +52,7 @@ class CalendarViewModel: ViewModelType {
     // 현재 페이지를 저장하는 Relay
     private let currentPageRelay = BehaviorRelay<Date>(value: Date())
     private let addButtonTapped = PublishRelay<Date>()
-    private let expensesData = BehaviorRelay<(date: Date, data: [MockMyCashBookModel], balance: Double)>(value: (Date(), [], 0))
+    private let expensesData = BehaviorRelay<(date: Date, data: [MockMyCashBookModel], balance: Int)>(value: (Date(), [], 0))
     
     
     // MARK: - Initalization
@@ -102,7 +102,7 @@ class CalendarViewModel: ViewModelType {
         
         input.didSelected
             .withUnretained(self)
-            .map { owner, date -> (date: Date, data: [MockMyCashBookModel], balance: Double) in
+            .map { owner, date -> (date: Date, data: [MockMyCashBookModel], balance: Int) in
                 owner.selectedDate = date
                 let remainingBudget = owner.calculateRemainingBudget(upTo: date)
                 return (date, owner.expensesForDate(date: date), remainingBudget)
@@ -115,7 +115,7 @@ class CalendarViewModel: ViewModelType {
         
         expenseRelay
             .withUnretained(self)
-            .map { owner, _ -> (date: Date, data: [MockMyCashBookModel], balance: Double) in
+            .map { owner, _ -> (date: Date, data: [MockMyCashBookModel], balance: Int) in
                 let remainingBudget = owner.calculateRemainingBudget(upTo: owner.selectedDate)
                 return (owner.selectedDate, owner.expensesForDate(date: owner.selectedDate), remainingBudget)
             }
@@ -147,7 +147,7 @@ class CalendarViewModel: ViewModelType {
             return MockMyCashBookModel(
                 amount: entity.amount,
                 cashBookID: entity.cashBookID ?? self.cashBookID,
-                caculatedAmount: 1234, // TODO: (#102)수정필요
+                caculatedAmount: entity.caculatedAmount,
                 category: entity.category ?? "",
                 country: entity.country ?? "",
                 expenseDate: entity.expenseDate ?? self.selectedDate,
@@ -220,25 +220,25 @@ class CalendarViewModel: ViewModelType {
         }
     }
     
-    /// 선택된 날짜의 총 지출 금액을 계산하는 메서드 (amount -> 원화 객체로 수정예정)
+    /// 선택된 날짜의 총 지출 금액을 계산하는 메서드
     /// - Parameter date: 총 지출 금액을 계산하는 날짜
     /// - Returns: 해당 날짜의 총 지출 금액
-    func totalExpense(date: Date) -> Double {
+    func totalExpense(date: Date) -> Int {
         let dailyExpenses = expensesForDate(date: date)
-        return dailyExpenses.reduce(0) { $0 + $1.caculatedAmount }
+        return dailyExpenses.reduce(0) { $0 + Int(round($1.caculatedAmount)) }
     }
     
     /// 특정 날짜까지의 예산 잔액을 계산하는 메서드
     /// - Parameter date: 계산할 기준 날짜
     /// - Returns: 해당 날짜까지의 예산 잔액
-    func calculateRemainingBudget(upTo date: Date) -> Double {
+    func calculateRemainingBudget(upTo date: Date) -> Int {
         // 해당 날짜까지의 모든 지출 필터링
         let allExpenses = expenseRelay.value.filter { expense in
             expense.expenseDate <= date
         }
         // 총 지출 계산
-        let totalExpense = Double(allExpenses.reduce(0.0) { $0 + $1.caculatedAmount })
+        let totalExpense = Int(allExpenses.reduce(0) { $0 + Int(round($1.caculatedAmount)) })
         // 초기 예산에서 총 지출을 빼서 잔액 계산
-        return Double(balance) - totalExpense
+        return balance - totalExpense
     }
 }


### PR DESCRIPTION
이슈 번호: #110 

## 요약
1. 이전 풀리퀘스트 코멘트 지적 수정
2. 캘린더 뷰의 expensLabel과 캘린더 지출목록의 지출, 잔액 수정
3. 캘린더 지출목록의 계산된 값을 환율을 넣어서 수정

## 작업 상세 내용
1번에 대한 코드 수정
```
    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
        let expenses = calendarViewModel.expensesForDate(date: calendarViewModel.selectedDate)
        let expense = expenses[indexPath.row]
        let originalID = expense.id
        let rates = CoreDataManager.shared.fetch(type: CurrencyEntity.self, predicate: nil)
        
        ModalViewManager.showModal(state: .editConsumption(data: expense, exchangeRate: rates))
            .compactMap { $0 as? MockMyCashBookModel }
            .subscribe(onNext: { [weak self] updatedExpense in
                var modifiedExpense = updatedExpense
                modifiedExpense.id = originalID  // ID 업데이트
                self?.calendarViewModel.updateExpense(modifiedExpense)
            })
            .disposed(by: disposeBag)
        
        tableView.deselectRow(at: indexPath, animated: true)
    }
```

2번작업 
```
// CalendarExpenseView.swift

let totalExpense = Double(expenses.reduce(0) { $0 + $1.caculatedAmount })

// CalendarExpenseCell.swift

        let formattedWonAmount = numberFormatter.string(from: NSNumber(value: Int(model.caculatedAmount))) ?? "0"

// CalenarViewModel.swift
// totalExpense 메서드
        return dailyExpenses.reduce(0) { $0 + $1.caculatedAmount }

// 총지출계산
        let totalExpense = Double(allExpenses.reduce(0.0) { $0 + $1.caculatedAmount })
```

3번 작업

```
output.addButtonTapped
            .withUnretained(self)
            .flatMap { owner, date in
                
                let rates = CoreDataManager.shared.fetch(
                    type: CurrencyEntity.self,
                    predicate: nil
                )
                
                return ModalViewManager.showModal(state: .createNewConsumption(data: .init(cashBookID: owner.calendarViewModel.cashBookID, date: date, exchangeRate: rates)))
                    .compactMap {
                        $0 as? MockMyCashBookModel
                    }
            }
            .asSignal(onErrorSignalWith: .empty())
            .emit { [weak self] data in
                CoreDataManager.shared.save(type: MyCashBookEntity.self, data: data)
                self?.calendarViewModel.loadExpenseData()
            }
            .disposed(by: disposeBag)


// 셀 수정 부분도 이와 동일함
```
## 리뷰어 공유사항
- Modal쪽 calcualtorAmount가 1234로 되있는것을 확인함. (수정예정이라고함)
## 스크린샷(선택)
![Simulator Screenshot - iPhone 16 Plus - 2025-02-12 at 13 18 49](https://github.com/user-attachments/assets/64d3861a-5cdb-46a9-8348-809f9a134dab)

