### PR TITLE
[fix] 통화코드 수정

### DIFF
--- a/TripLog/TripLog/Feat-Crois/ModalViewController/Model/Currencys.swift
+++ b/TripLog/TripLog/Feat-Crois/ModalViewController/Model/Currencys.swift
@@ -15,13 +15,13 @@ import Foundation
 /// - BND (브루나이 달러)
 /// - CAD (캐나다 달러)
 /// - CHF (스위스 프랑)
-/// - CNH (위안화)
+/// - CNH (중국 위안)
 /// - DKK (덴마크 크로네)
 /// - EUR (유로)
 /// - GBP (영국 파운드)
 /// - HKD (홍콩 달러)
 /// - IDR (인도네시아 루피아)
-/// - JPY (일본 옌)
+/// - JPY (일본 엔)
 /// - KRW (한국 원)
 /// - KWD (쿠웨이트 디나르)
 /// - MYR (말레이시아 링기트)
@@ -33,29 +33,29 @@ import Foundation
 /// - THB (태국 바트)
 /// - USD (미국 달러)
 enum Currency: String, CaseIterable {
-    case AED = "AED(아랍에미리트 디르함)"     // 아랍에미리트
-    case AUD = "AUD(호주 달러)"              // 호주
-    case BHD = "BHD(바레인 디나르)"          // 바레인
-    case BND = "BND(브루나이 달러)"          // 브루나이
-    case CAD = "CAD(캐나다 달러)"            // 캐나다
-    case CHF = "CHF(스위스 프랑)"            // 스위스
-    case CNH = "CNH(중국 위안)"                // 중국
-    case DKK = "DKK(덴마크 크로네)"         // 덴마크
-    case EUR = "EUR(유로)"                  // 유럽 연합
-    case GBP = "GBP(영국 파운드)"           // 영국
-    case HKD = "HKD(홍콩 달러)"             // 홍콩
-    case IDR = "IDR(인도네시아 루피아)"      // 인도네시아
-    case JPY = "JPY(일본 엔)"               // 일본
-    case KRW = "KRW(한국 원)"               // 대한민국
-    case KWD = "KWD(쿠웨이트 디나르)"       // 쿠웨이트
-    case MYR = "MYR(말레이시아 링기트)"     // 말레이시아
-    case NOK = "NOK(노르웨이 크로네)"       // 노르웨이
-    case NZD = "NZD(뉴질랜드 달러)"        // 뉴질랜드
-    case SAR = "SAR(사우디 리얄)"         // 사우디아라비아
-    case SEK = "SEK(스웨덴 크로나)"        // 스웨덴
-    case SGD = "SGD(싱가포르 달러)"         // 싱가포르
-    case THB = "THB(태국 바트)"             // 태국
-    case USD = "USD(미국 달러)"             // 미국
+    case AED = "AED(아랍에미리트 디르함)"
+    case AUD = "AUD(호주 달러)"
+    case BHD = "BHD(바레인 디나르)"
+    case BND = "BND(브루나이 달러)"
+    case CAD = "CAD(캐나다 달러)"
+    case CHF = "CHF(스위스 프랑)"
+    case CNH = "CNH(중국 위안)"
+    case DKK = "DKK(덴마크 크로네)"
+    case EUR = "EUR(유로)"
+    case GBP = "GBP(영국 파운드)"
+    case HKD = "HKD(홍콩 달러)"
+    case IDR = "IDR(인도네시아 루피아)"
+    case JPY = "JPY(일본 엔)"
+    case KRW = "KRW(한국 원)"
+    case KWD = "KWD(쿠웨이트 디나르)"
+    case MYR = "MYR(말레이시아 링기트)"
+    case NOK = "NOK(노르웨이 크로네)"
+    case NZD = "NZD(뉴질랜드 달러)"
+    case SAR = "SAR(사우디 리얄)"
+    case SEK = "SEK(스웨덴 크로나)"
+    case SGD = "SGD(싱가포르 달러)"
+    case THB = "THB(태국 바트)"
+    case USD = "USD(미국 달러)"
 
     // 모든 케이스의 배열 제공
     static var allCurrencies: [String] {

--- a/TripLog/TripLog/Feat-Crois/ModalViewController/Model/Currencys.swift
+++ b/TripLog/TripLog/Feat-Crois/ModalViewController/Model/Currencys.swift
@@ -7,35 +7,55 @@
 
 import Foundation
 
-/// 모든 통화를 모아두는 enum
+/// 나라별 통화코드(총 26개국)
+///
+/// - AED (아랍에미리트 디르함)
+/// - AUD (호주 달러)
+/// - BHD (바레인 디나르)
+/// - BND (브루나이 달러)
+/// - CAD (캐나다 달러)
+/// - CHF (스위스 프랑)
+/// - CNH (위안화)
+/// - DKK (덴마크 크로네)
+/// - EUR (유로)
+/// - GBP (영국 파운드)
+/// - HKD (홍콩 달러)
+/// - IDR (인도네시아 루피아)
+/// - JPY (일본 옌)
+/// - KRW (한국 원)
+/// - KWD (쿠웨이트 디나르)
+/// - MYR (말레이시아 링기트)
+/// - NOK (노르웨이 크로네)
+/// - NZD (뉴질랜드 달러)
+/// - SAR (사우디 리얄)
+/// - SEK (스웨덴 크로나)
+/// - SGD (싱가포르 달러)
+/// - THB (태국 바트)
+/// - USD (미국 달러)
 enum Currency: String, CaseIterable {
-    case KRW = "KRW(원)"         // 대한민국
-    case USD = "USD(달러)"       // 미국
-    case EUR = "EUR(유로)"       // 유럽 연합
-    case JPY = "JPY(엔)"         // 일본
-    case CNY = "CNY(위안)"       // 중국
-    case GBP = "GBP(파운드)"     // 영국
-    case AUD = "AUD(호주 달러)"  // 호주
-    case CAD = "CAD(캐나다 달러)" // 캐나다
-    case CHF = "CHF(스위스 프랑)" // 스위스
-    case HKD = "HKD(홍콩 달러)"  // 홍콩
-    case NZD = "NZD(뉴질랜드 달러)" // 뉴질랜드
-    case SGD = "SGD(싱가포르 달러)" // 싱가포르
-    case SEK = "SEK(스웨덴 크로나)" // 스웨덴
-    case NOK = "NOK(노르웨이 크로네)" // 노르웨이
-    case DKK = "DKK(덴마크 크로네)" // 덴마크
-    case ZAR = "ZAR(남아프리카 랜드)" // 남아프리카공화국
-    case INR = "INR(루피)"       // 인도
-    case MYR = "MYR(링깃)"      // 말레이시아
-    case IDR = "IDR(루피아)"     // 인도네시아
-    case PHP = "PHP(페소)"      // 필리핀
-    case THB = "THB(바트)"       // 태국
-    case MXN = "MXN(멕시코 페소)" // 멕시코
-    case VND = "VND(동)"        // 베트남
-    case BRL = "BRL(브라질 헤알)" // 브라질
-    case RUB = "RUB(루블)"      // 러시아
-    case SAR = "SAR(리얄)"      // 사우디아라비아
-    case TRY = "TRY(리라)"      // 터키
+    case AED = "AED(아랍에미리트 디르함)"     // 아랍에미리트
+    case AUD = "AUD(호주 달러)"              // 호주
+    case BHD = "BHD(바레인 디나르)"          // 바레인
+    case BND = "BND(브루나이 달러)"          // 브루나이
+    case CAD = "CAD(캐나다 달러)"            // 캐나다
+    case CHF = "CHF(스위스 프랑)"            // 스위스
+    case CNH = "CNH(중국 위안)"                // 중국
+    case DKK = "DKK(덴마크 크로네)"         // 덴마크
+    case EUR = "EUR(유로)"                  // 유럽 연합
+    case GBP = "GBP(영국 파운드)"           // 영국
+    case HKD = "HKD(홍콩 달러)"             // 홍콩
+    case IDR = "IDR(인도네시아 루피아)"      // 인도네시아
+    case JPY = "JPY(일본 엔)"               // 일본
+    case KRW = "KRW(한국 원)"               // 대한민국
+    case KWD = "KWD(쿠웨이트 디나르)"       // 쿠웨이트
+    case MYR = "MYR(말레이시아 링기트)"     // 말레이시아
+    case NOK = "NOK(노르웨이 크로네)"       // 노르웨이
+    case NZD = "NZD(뉴질랜드 달러)"        // 뉴질랜드
+    case SAR = "SAR(사우디 리얄)"         // 사우디아라비아
+    case SEK = "SEK(스웨덴 크로나)"        // 스웨덴
+    case SGD = "SGD(싱가포르 달러)"         // 싱가포르
+    case THB = "THB(태국 바트)"             // 태국
+    case USD = "USD(미국 달러)"             // 미국
 
     // 모든 케이스의 배열 제공
     static var allCurrencies: [String] {


### PR DESCRIPTION
이슈 번호: close #112 

## 요약
- 중국 위안 코드 수정
- 통화코드 알파벳 정렬

## 작업 상세 내용
- Currency 내의 통화코드를 API 기준으로 수정하였습니다.
- 통화코드를 알파벳 순으로 정렬하였습니다.

## 리뷰어 공유사항
- 베트남, 필리핀같은 아시아 계열의 나라의 환율은 API에서 지원되지 않아요
- 그래서 리스트에 있는 나라를 제외한 환율은 조회할 수 없어요
