### PR TITLE
[Refactor] 가계부 리스트 UI수정 및 새로운 가계부 생성 로직 수정

### DIFF
--- a/TripLog/TripLog/Feat-Hamsik/Extension/CashBookEntity+Ext.swift
+++ b/TripLog/TripLog/Feat-Hamsik/Extension/CashBookEntity+Ext.swift
@@ -39,8 +39,6 @@ extension CashBookEntity: CoreDataManagable {
         let entityName = EntityKeys.Name.CashBookEntity.rawValue
         let element = CashBookElement()
         guard let entity = NSEntityDescription.entity(forEntityName: entityName, in: context) else { return }
-        let fetchRequest: NSFetchRequest<CashBookEntity> = CashBookEntity.fetchRequest()
-        fetchRequest.predicate = NSPredicate(format: "\(element.tripName) == %@", data.tripName as CVarArg)
         let properties: [String: Any] = [
             element.id : data.id,
             element.budget : data.budget,
@@ -50,30 +48,21 @@ extension CashBookEntity: CoreDataManagable {
             element.tripName : data.tripName
         ]
         
-        do {
-            let existingItems = try context.fetch(fetchRequest)
-            if existingItems.isEmpty {
-                // 중복된 항목이 없으면 저장
-                // 비동기 저장
-                context.performAndWait {
-                    let att = NSManagedObject(entity: entity, insertInto: context)
-                    properties.forEach { key, value in
-                        att.setValue(value, forKey: key)
-                    }
-                
-                    do {
-                        try context.save()
-                        print("저장 성공: \(data.note)")
-                    } catch {
-                        print("데이터 저장 실패: \(error)")
-                    }
-                }
-            } else {
-                print("이미 존재하는 항목입니다.")
+        // 비동기 저장
+        context.performAndWait {
+            let att = NSManagedObject(entity: entity, insertInto: context)
+            properties.forEach { key, value in
+                att.setValue(value, forKey: key)
             }
-        } catch {
-            print("Fetch 오류: \(error.localizedDescription)")
+            
+            do {
+                try context.save()
+                print("저장 성공: \(data.note)")
+            } catch {
+                print("데이터 저장 실패: \(error)")
+            }
         }
+        
     }
     
     

--- a/TripLog/TripLog/Feat-Jeff/CashBookList/View/CashBookListViewController.swift
+++ b/TripLog/TripLog/Feat-Jeff/CashBookList/View/CashBookListViewController.swift
@@ -36,6 +36,9 @@ final class CashBookListViewController: UIViewController {
         // 스크롤 제거
         $0.showsHorizontalScrollIndicator = false
         $0.showsVerticalScrollIndicator = false
+        
+        // 하단 여백
+        $0.contentInset = UIEdgeInsets(top: 0, left: 0, bottom: 40, right: 0)
     }
     
     // RxdataSource(animated)
@@ -202,6 +205,9 @@ private extension CashBookListViewController {
     func listCollectionViewLayout() -> UICollectionViewLayout {
         let layout = UICollectionViewCompositionalLayout { sectionIndex, layoutEnvironment -> NSCollectionLayoutSection in
             var configuration = UICollectionLayoutListConfiguration(appearance: .plain)
+            
+            // 셀 간의 seperator구분 선 삭제
+            configuration.showsSeparators = false
             
             // 셀 뒤의 스크롤뷰 색상 변경
             configuration.backgroundColor = UIColor.CustomColors.Background.background

--- a/TripLog/TripLog/Feat-Jeff/CashBookList/ViewModel/CashBookListViewModel.swift
+++ b/TripLog/TripLog/Feat-Jeff/CashBookList/ViewModel/CashBookListViewModel.swift
@@ -31,7 +31,11 @@ final class CashBookListViewModel: NSObject, ViewModelType, NSFetchedResultsCont
     /// 타입은 제네릭으로 선언, 정렬이 필수적으로 필요
     private lazy var fetchedResultsController: NSFetchedResultsController<CashBookEntity> = {
         let fetchRequest: NSFetchRequest<CashBookEntity> = CashBookEntity.fetchRequest()
-        fetchRequest.sortDescriptors = [NSSortDescriptor(key: "departure", ascending: true)]
+        // 정렬 설정(1순위 출발날짜, 2순위 도착날짜)
+        fetchRequest.sortDescriptors = [
+            NSSortDescriptor(key: "departure", ascending: true),
+            NSSortDescriptor(key: "homecoming", ascending: true)
+        ]
         
         let controller = NSFetchedResultsController(
             fetchRequest: fetchRequest,


### PR DESCRIPTION
이슈 번호: 

## 요약
- 가계부 리스트 셀 하단의 실선 제거
- 가계부 리스트 정렬 기준 추가
- 가계부 리스트 셀 하단의 여유 공간 추가
- 가계부 생성시 동일한 이름도 추가가 가능하게 수정
  
## 작업 상세 내용
### # 가계부 생성 로직 수정
기존에는 가계부의 이름을 코어데이터에서 검색을 통해 막혀있던 로직을 동일한 이름도 추가가 되도록 로직 수정하였습니다.
### # 가계부 리스트 
- 출발일을 기준으로  셀이 정렬이 되었지만, 동일한 출발일이 있는 경우를 대비해 도착일이 두번째 순위로 정렬이 되도록 수정하였습니다.
- 셀이 많이 생겼을 경우 셀 하단이 탭바와 가까웠던 부분을 여유 공간을 주었습니다.
- 생성된 셀 하단에 실선이 존재했었는데 그 부분은 **UICollectionLayoutListConfiguration**가 추가가 되면서 테이블 뷰와 같은 구분선이 자동으로 추가가 되어 해당 기능을 비활성화 하였습니다.

## 리뷰어 공유사항

## 스크린샷(선택)
![Screenshot 2025-02-13 at 2 23 13 PM](https://github.com/user-attachments/assets/7a645502-1cef-4919-b846-e7d10f1332bb)


