### PR TITLE
[feat] 가계부 삭제 시, 관련 지출내역 동시 삭제

### DIFF
--- a/TripLog/TripLog/Feat-Hamsik/Extension/CashBookEntity+Ext.swift
+++ b/TripLog/TripLog/Feat-Hamsik/Extension/CashBookEntity+Ext.swift
@@ -161,20 +161,27 @@ extension CashBookEntity: CoreDataManagable {
     ///   - entityID: 삭제할 CashBookEntity ID
     ///   - context: CoreData 인스턴스
     static func delete(entityID: UUID?, context: NSManagedObjectContext) {
-        let entityName = EntityKeys.Name.CashBookEntity.rawValue
-        let element = CashBookElement()
+        let cashBookEntityName = EntityKeys.Name.CashBookEntity.rawValue
+        let cashBookID = CashBookElement().id
+        let myCashBookEntityName = EntityKeys.Name.MyCashBookEntity.rawValue
+        let myCashBookParentID = MyCashBookElement().cashBookID
         guard let entityID = entityID else { return }
         
-        let fetchRequest = NSFetchRequest<NSFetchRequestResult>(entityName: entityName)
-        fetchRequest.predicate = NSPredicate(format: "\(element.id) == %@", entityID as CVarArg)
-        let deleteRequest = NSBatchDeleteRequest(fetchRequest: fetchRequest)
+        let cashBookFetchRequest = NSFetchRequest<NSFetchRequestResult>(entityName: cashBookEntityName)
+        cashBookFetchRequest.predicate = NSPredicate(format: "\(cashBookID) == %@", entityID as CVarArg)
+        let cashBookDeleteRequest = NSBatchDeleteRequest(fetchRequest: cashBookFetchRequest)
+        
+        let myCashBookFetchRequest = NSFetchRequest<NSFetchRequestResult>(entityName: myCashBookEntityName)
+        myCashBookFetchRequest.predicate = NSPredicate(format: "\(myCashBookParentID) == %@", entityID as CVarArg)
+        let myCashBookDeleteRequest = NSBatchDeleteRequest(fetchRequest: myCashBookFetchRequest)
         
         do {
-            try context.execute(deleteRequest)
+            try context.execute(cashBookDeleteRequest)
+            try context.execute(myCashBookDeleteRequest)
             context.refreshAllObjects()
-            debugPrint("\(entityName)에서 id \(entityID) 데이터 삭제 완료")
+            debugPrint("\(cashBookEntityName)에서 id \(entityID) 데이터 삭제 완료")
         } catch {
-            debugPrint("\(entityName)에서 id \(entityID) 데이터 삭제 실패: \(error)")
+            debugPrint("\(cashBookEntityName)에서 id \(entityID) 데이터 삭제 실패: \(error)")
         }
     }
 }


### PR DESCRIPTION
이슈 번호: close #123 

## 요약
- `CashBookEntity`의 `delete` 함수에서 동시 삭제 기능 구현
- `CashBookEntity` 객체 삭제 시, 관련된 `MyCashBookEntity` 객체(들) 삭제

## 작업 상세 내용
```swift
// CashBook 삭제요청 객체
 let cashBookFetchRequest = NSFetchRequest<NSFetchRequestResult>(entityName: cashBookEntityName)
 cashBookFetchRequest.predicate = NSPredicate(format: "\(cashBookID) == %@", entityID as CVarArg)
 let cashBookDeleteRequest = NSBatchDeleteRequest(fetchRequest: cashBookFetchRequest)

// MyCashBook 삭제요청 객체(추가)
 let myCashBookFetchRequest = NSFetchRequest<NSFetchRequestResult>(entityName: myCashBookEntityName)
 myCashBookFetchRequest.predicate = NSPredicate(format: "\(myCashBookParentID) == %@", entityID as CVarArg)
 let myCashBookDeleteRequest = NSBatchDeleteRequest(fetchRequest: myCashBookFetchRequest)
```
```swift
do {
    // 삭제 진행
    try context.execute(cashBookDeleteRequest)
    try context.execute(myCashBookDeleteRequest)
    context.refreshAllObjects()
    debugPrint("\(cashBookEntityName)에서 id \(entityID) 데이터 삭제 완료")
} catch {
        debugPrint("\(cashBookEntityName)에서 id \(entityID) 데이터 삭제 실패: \(error)")
}
```