### PR TITLE
Fix/ 환율 저장 로직 수정

### DIFF
--- a/TripLog/TripLog/MainViewController.swift
+++ b/TripLog/TripLog/MainViewController.swift
@@ -50,17 +50,21 @@ class MainViewController: UIViewController {
         setupUI()
         
         Task {
-            if CoreDataManager.shared.fetch(type: CurrencyEntity.self).isEmpty {
-                do {
-                    try await SyncManager.shared.syncCoreDataToFirestore()
-                } catch {
-                    debugPrint(error)
-                }
-            } else {
-                _ = CoreDataManager.shared.fetch(type: CurrencyEntity.self,
-                                                 predicate: Date.formattedDateString(from: Date()))
-            }
+            try await SyncManager.shared.syncCoreDataToFirestore()
         }
+        
+//        Task {
+//            if CoreDataManager.shared.fetch(type: CurrencyEntity.self).isEmpty {
+//                do {
+//                    try await SyncManager.shared.syncCoreDataToFirestore()
+//                } catch {
+//                    debugPrint(error)
+//                }
+//            } else {
+//                _ = CoreDataManager.shared.fetch(type: CurrencyEntity.self,
+//                                                 predicate: Date.formattedDateString(from: Date()))
+//            }
+//        }
     }
     
     override func viewWillAppear(_ animated: Bool) {

--- a/TripLog/TripLog/MainViewController.swift
+++ b/TripLog/TripLog/MainViewController.swift
@@ -50,21 +50,17 @@ class MainViewController: UIViewController {
         setupUI()
         
         Task {
-            try await SyncManager.shared.syncCoreDataToFirestore()
+            if CoreDataManager.shared.fetch(type: CurrencyEntity.self).isEmpty {
+                do {
+                    try await SyncManager.shared.syncCoreDataToFirestore()
+                } catch {
+                    debugPrint(error)
+                }
+            } else {
+                _ = CoreDataManager.shared.fetch(type: CurrencyEntity.self,
+                                                 predicate: Date.formattedDateString(from: Date()))
+            }
         }
-        
-//        Task {
-//            if CoreDataManager.shared.fetch(type: CurrencyEntity.self).isEmpty {
-//                do {
-//                    try await SyncManager.shared.syncCoreDataToFirestore()
-//                } catch {
-//                    debugPrint(error)
-//                }
-//            } else {
-//                _ = CoreDataManager.shared.fetch(type: CurrencyEntity.self,
-//                                                 predicate: Date.formattedDateString(from: Date()))
-//            }
-//        }
     }
     
     override func viewWillAppear(_ animated: Bool) {

--- a/TripLog/TripLog/Source/AppHelp/Extension/CurrencyEntity+Ext.swift
+++ b/TripLog/TripLog/Source/AppHelp/Extension/CurrencyEntity+Ext.swift
@@ -70,8 +70,11 @@ extension CurrencyEntity: CoreDataManagable {
                         result.sort(by: { Int($0.rateDate ?? "") ?? 0 > Int($1.rateDate ?? "") ?? 0 })
                         debugPrint("✅ 데이터 연동 성공!")
                         
+                        return result
+                        
                     } catch {
                         debugPrint("❌ Firestore 연동 실패", error.localizedDescription)
+                        return result
                     }
                 }
                 
@@ -80,9 +83,7 @@ extension CurrencyEntity: CoreDataManagable {
             }
         }
         
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
-            debugPrint("✨ result를 반환합니다 ✨")
-        }
+        debugPrint("✨ result를 반환합니다 ✨")
         
         return result
     }

--- a/TripLog/TripLog/Source/AppHelp/Extension/CurrencyEntity+Ext.swift
+++ b/TripLog/TripLog/Source/AppHelp/Extension/CurrencyEntity+Ext.swift
@@ -42,83 +42,49 @@ extension CurrencyEntity: CoreDataManagable {
     /// - Returns: 검색결과(특정 검색 결과)
     static func fetch(context: NSManagedObjectContext, predicate: Any? = nil) -> [Entity] {
         let request: NSFetchRequest<CurrencyEntity> = CurrencyEntity.fetchRequest()
-        let element = CurrencyElement()
         var result = [CurrencyEntity]()
-        var resultType: CurrencyRateResultType = .isEmpty
-        var retryCount = 0
         
-        guard var searchDate = predicate as? String else {
-            do {
-                let results = try context.fetch(request)
-                debugPrint("CurrencyEntity fetchCount: \(results.count)")
-                return results
-            } catch {
-                debugPrint("오류 발생: \(error)")
-                return []
-            }
+        do {
+            result = try context.fetch(request)
+            result.sort(by: { Int($0.rateDate ?? "") ?? 0 > Int($1.rateDate ?? "") ?? 0 })
+        } catch {
+            debugPrint("코어 데이터 load 실패", error.localizedDescription)
+            return []
         }
         
-        while retryCount < 15 {
-            // 검색 조건이 있을 때 동작
-            request.predicate = NSPredicate(format: "\(element.rateDate) == %@", searchDate)
-            do {
-                result = try context.fetch(request)
-                resultType = checkResult(result)
-                
-                switch resultType {
-                    // 데이터 자체가 없을 때(생성하기)
-                case .isEmpty:
-                    retryCount += 1
-                    FireStoreManager.shared.generateCurrencyRate(date: searchDate) { result in
-                        switch result {
-                        case true:
-                            Task {
-                                debugPrint("\(searchDate) 데이터 생성")
-                                do {
-                                    try await SyncManager.shared.syncCoreDataToFirestore()
-                                    debugPrint("동기화 완료") // 동기화 완료가 좀 느리게 동작함
-                                } catch {
-                                    debugPrint("\(searchDate)데이터 생성 후 데이터 동기화 실패")
-                                }
-                            }
-                        case false:
-                            searchDate = Date.getPreviousDate(from: searchDate) ?? searchDate
-                            debugPrint("API 통신 실패")
-                        }
+        guard let searchDate = predicate as? String,
+              result.filter({ $0.rateDate == searchDate }).isEmpty
+        else {
+            debugPrint("✨ 환율 데이터 있음, 현재 최신 환율 데이터 날짜:", result.first?.rateDate ?? "nil")
+            return result
+        }
+
+        
+        // 검색 조건이 있을 경우
+        FireStoreManager.shared.generateCurrencyRate(date: searchDate) { isSuccess in
+            if isSuccess {
+                Task {
+                    do {
+                        try await SyncManager.shared.syncCoreDataToFirestore()
+                        result = try context.fetch(request)
+                        result.sort(by: { Int($0.rateDate ?? "") ?? 0 > Int($1.rateDate ?? "") ?? 0 })
+                        debugPrint("✅ 데이터 연동 성공!")
                         
+                    } catch {
+                        debugPrint("❌ Firestore 연동 실패", error.localizedDescription)
                     }
-                    continue
-                    
-                    // 데이터에 내용이 없을 때(검색일자 감소)
-                case .noData:
-                    retryCount += 1
-                    // 검색 조건을 수정하거나 사용자에게 알림
-                    debugPrint("검색날짜 변경 전: \(searchDate)")
-                    searchDate = Date.getPreviousDate(from: searchDate) ?? searchDate
-                    debugPrint("검색날짜 변경 후: ->\(searchDate)")
-                    continue
-                    
-                    // 정상 데이터 확인
-                case .success:
-                    debugPrint("정상 값 찾음: \(searchDate)")
-                    return result // 반복문 종료
                 }
-            } catch {
-                debugPrint("오류 발생: \(error)")
-                return []
+                
+            } else {
+                debugPrint("❌ API 통신 실패")
             }
         }
         
-        func checkResult(_ result: [CurrencyEntity?]) -> CurrencyRateResultType {
-            if result.isEmpty {
-                return .isEmpty
-            } else if result.first??.currencyCode == nil {
-                return .noData
-            } else {
-                return .success
-            }
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
+            debugPrint("✨ result를 반환합니다 ✨")
         }
-        return []
+        
+        return result
     }
     
     /// (사용X)

--- a/TripLog/TripLog/Source/View/ModalView/ModalView.swift
+++ b/TripLog/TripLog/Source/View/ModalView/ModalView.swift
@@ -206,6 +206,7 @@ private extension ModalView {
     /// - Returns: 환율을 적용한 원화
     func exchangeRateCalculation(_ country: String, _ amount: Double) -> Double {
         guard let currency = exchangeRate?.filter({ $0.currencyCode?.prefix(3) ?? "" == country }).first else { return 0 }
+        debugPrint("🗓️ 현재 적용된 환율 날짜:", currency.rateDate ?? "nil")
         
         var result: Double = 0
         


### PR DESCRIPTION
이슈 번호: 없음

## 요약
- 환율 저장 로직 (CoreData fetch 로직) 수정

## 작업 상세 내용
#### 기존 코드
```swift
static func fetch(context: NSManagedObjectContext, predicate: Any? = nil) -> [Entity] {
        let request: NSFetchRequest<CurrencyEntity> = CurrencyEntity.fetchRequest()
        let element = CurrencyElement()
        var result = [CurrencyEntity]()
        var resultType: CurrencyRateResultType = .isEmpty
        var retryCount = 0
        
        guard var searchDate = predicate as? String else {
            do {
                let results = try context.fetch(request)
                debugPrint("CurrencyEntity fetchCount: \(results.count)")
                return results
            } catch {
                debugPrint("오류 발생: \(error)")
                return []
            }
        }
        
        while retryCount < 15 {
            // 검색 조건이 있을 때 동작
            request.predicate = NSPredicate(format: "\(element.rateDate) == %@", searchDate)
            do {
                result = try context.fetch(request)
                resultType = checkResult(result)
                
                switch resultType {
                    // 데이터 자체가 없을 때(생성하기)
                case .isEmpty:
                    retryCount += 1
                    FireStoreManager.shared.generateCurrencyRate(date: searchDate) { result in
                        switch result {
                        case true:
                            Task {
                                debugPrint("\(searchDate) 데이터 생성")
                                do {
                                    try await SyncManager.shared.syncCoreDataToFirestore()
                                    debugPrint("동기화 완료") // 동기화 완료가 좀 느리게 동작함
                                } catch {
                                    debugPrint("\(searchDate)데이터 생성 후 데이터 동기화 실패")
                                }
                            }
                        case false:
                            searchDate = Date.getPreviousDate(from: searchDate) ?? searchDate
                            debugPrint("API 통신 실패")
                        }
                        
                    }
                    continue
                    
                    // 데이터에 내용이 없을 때(검색일자 감소)
                case .noData:
                    retryCount += 1
                    // 검색 조건을 수정하거나 사용자에게 알림
                    debugPrint("검색날짜 변경 전: \(searchDate)")
                    searchDate = Date.getPreviousDate(from: searchDate) ?? searchDate
                    debugPrint("검색날짜 변경 후: ->\(searchDate)")
                    continue
                    
                    // 정상 데이터 확인
                case .success:
                    debugPrint("정상 값 찾음: \(searchDate)")
                    return result // 반복문 종료
                }
            } catch {
                debugPrint("오류 발생: \(error)")
                return []
            }
        }
        
        func checkResult(_ result: [CurrencyEntity?]) -> CurrencyRateResultType {
            if result.isEmpty {
                return .isEmpty
            } else if result.first??.currencyCode == nil {
                return .noData
            } else {
                return .success
            }
        }
        return []
    }
```
<문제점>
- 코드가 너무 길어 가독성이 떨어짐
- while문을 통한 반복문이 적합하지 않음
- 데이터가 비어있을 때, 이전 날짜로 다시 찾지 않고 빈 값을 반환하는 문제

#### 코드 수정
```swift
static func fetch(context: NSManagedObjectContext, predicate: Any? = nil) -> [Entity] {
        let request: NSFetchRequest<CurrencyEntity> = CurrencyEntity.fetchRequest()
        var result = [CurrencyEntity]()
        
        do {
            result = try context.fetch(request)
            result.sort(by: { Int($0.rateDate ?? "") ?? 0 > Int($1.rateDate ?? "") ?? 0 })
        } catch {
            debugPrint("코어 데이터 load 실패", error.localizedDescription)
            return []
        }
        
        guard let searchDate = predicate as? String,
              result.filter({ $0.rateDate == searchDate }).isEmpty
        else {
            debugPrint("✨ 환율 데이터 있음, 현재 최신 환율 데이터 날짜:", result.first?.rateDate ?? "nil")
            return result
        }
        
        // 검색 조건이 있을 경우
        FireStoreManager.shared.generateCurrencyRate(date: searchDate) { isSuccess in
            if isSuccess {
                Task {
                    do {
                        try await SyncManager.shared.syncCoreDataToFirestore()
                        result = try context.fetch(request)
                        result.sort(by: { Int($0.rateDate ?? "") ?? 0 > Int($1.rateDate ?? "") ?? 0 })
                        debugPrint("✅ 데이터 연동 성공!")
                        
                        return result
                        
                    } catch {
                        debugPrint("❌ Firestore 연동 실패", error.localizedDescription)
                        return result
                    }
                }
                
            } else {
                debugPrint("❌ API 통신 실패")
            }
        }
        
        debugPrint("✨ result를 반환합니다 ✨")
        
        return result
    }
```
<수정 사항>
- 코드 가독성 향상을 위해 불필요한 코드 삭제
- while 반복문을 없애고, filter를 통한 조건문으로 대체

#### 두 로직 비교
1. 기존 로직:
기존 로직은 predicate의 존재 유무로 분기를 나누어 없을 경우 그대로 코어 데이터를 패치, 값이 있을 경우 String 데이터를 `NSPredicate`로 변환하여 request를 만들고 코어 데이터를 패치.
이후 패치된 데이터가 비어있지 않다면 return 하고, 비어있다면 조건 날짜를 1일 전으로 되돌려 while 문으로 15회 반복한다.

2. 새로운 로직:
일단 코어데이터를 패치하고, predicate가 빈 값이 아니라면, filter를 통해 패치된 데이터의 rateDate 값과 동일한 값을 가진 데이터 배열을 생성하고, 해당 배열이 빈 값(isEmpty)인지 확인.
만일 빈 값이라면 Firestore를 통해 환율 데이터를 새로 저장하고, 코어데이터와 Sync.
이 때, sort를 통해 데이터 배열이 rateDate의 내림차순(최신 순)으로 정렬시킴 -> CoreData의 배열은 순서 보장이 되지 않음. 따라서 first를 통해 가장 최신의 데이터를 사용하기 위해 정렬을 진행.

## 리뷰어 공유사항
Firestore를 지켜보며 여러번 테스트 결과, 빈 배열([])일 때도 무사히 작동하고, 데이터가 있다면 해당 데이터를 사용해서 값을 적용하는 것을 확인했습니다.
다만, 모든 경우에 대한 테스트를 진행한 것이 아니기 때문에 여전히 문제가 발생할 수도 있습니다.
더 좋은 의견이 있다면 코멘트 부탁드립니다.